### PR TITLE
manage.py should default to production settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN pip install -r /requirements/dev.txt
 ADD . /srv
 WORKDIR /srv
 
+ENV DJANGO_SETTINGS_MODULE website.dev_settings
 CMD ["python", "manage.py", "runserver_plus", "0.0.0.0:5000"]
+

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "website.dev_settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "website.settings")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
This is so that the deployment script can run
`manage.py migrate` without having to install
unnecessary `dev_settings`.
## QA

``` bash
make clean-app run
```

Check the site still works.
