### PR TITLE
Remove only the correct CSS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ docs/_build/
 
 # PyBuilder
 target/
-*.css
+
+# Sass
+static/css/**/*.css
 .sass-cache/
 *.css.map
+

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ import-new-pages:
 # Delete any compiled CSS files
 clean-css:
 	rm -rf .sass-cache
-	find . -name '*.css' | xargs rm -f
+	find . -name 'statis/css/*.css' | xargs rm -f
 
 # Remove the database container (discards existing data, and deletes web as well)
 clean-db:


### PR DESCRIPTION
So what use to happen is if you ran `make clean-css` you would see
a removed CSS file in `static/fonts/fonts.css`.

However, since `make sass-compile` only builds CSS in `static/css`,
therefore `make clean-css` should only remove CSS in this dir.

And therefore we should also only ignore CSS files in `static/css`.
## QA
- `make clean-css; git status`: Make sure we didnt remove any tracked files
- `make clean-css run`: Make sure the site styling still works
