### PR TITLE
Fix static files

### DIFF
--- a/website/wsgi.py
+++ b/website/wsgi.py
@@ -10,7 +10,9 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from dj_static import Cling
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "website.settings")
 
-application = get_wsgi_application()
+application = Cling(get_wsgi_application())
+


### PR DESCRIPTION
After many hours of investigation, I re-remembered that we need 
https://github.com/kennethreitz/dj-static to serve static files in
production, or with DEBUG turned off.

Simple fix really.
## QA

Edit `website/settings.py` and change `DEBUG` to `False`.

Now run the site:

```
make run
```

And check static files work.
