### PR TITLE
remove border from download page list

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -102,6 +102,7 @@ body.download {
 	.where-to-find-us li {
 		padding: 0 0 8px 26px;
 		background: url("../img/icons/icon-irc.png") 0 4px no-repeat;
+		border: none;
 		margin-bottom: 8px;
 	}
 


### PR DESCRIPTION
### Done

Removed border from the lists on the bottom row on /download
### QA

See that there is no border on the list on /download
### Card

https://canonical.leankit.com/Boards/View/111185042/119138358

Fixes #58 
