### PR TITLE
Add "make replace-page" option to create migration to replace page migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,18 @@ export-page:
 		docker-compose run web ./manage.py create-page-migration website/page-data/$${url}.json; \
 	fi
 
+# Given a URL, export the page data for that URL as JSON
+replace-page:
+	@read -p "Enter page URL path (without preceding slash): " url; \
+	if [[ -n "$${url}" ]]; then \
+		echo "Exporting to website/page-data/$${url}.json"; \
+		data=$$(docker-compose run web ./manage.py export-page-json $${url}); \
+		if [[ $$? > 0 ]]; then echo -e "ERROR:\n$${data}"; exit 1; \
+		else echo "$${data}" > website/page-data/$${url}.json; fi; \
+		echo "Creating migration to replace page data at $${url}"; \
+		docker-compose run web ./manage.py replace-page-migration $${url} website/page-data/$${url}.json; \
+	fi
+
 # Delete any compiled CSS files
 clean-css:
 	rm -rf .sass-cache

--- a/website/management/commands/replace-page-migration.py
+++ b/website/management/commands/replace-page-migration.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+# System
+import os
+import re
+import glob
+
+# Modules
+from django.core.management.base import BaseCommand
+from jinja2 import Template
+
+
+def latest_migration(migration_dir):
+    """
+    Get the most recent migration name
+    """
+
+    file_search = os.path.join(migration_dir, '[0-9][0-9][0-9][0-9]_*.py')
+    files = sorted(glob.glob(file_search))
+    last_file = os.path.basename(files[-1])
+    return last_file.replace('.py', '')
+
+
+def next_migration_number(migration_name):
+    """
+    Get the next migration number as a 4 digit string
+    """
+
+    next_number = int(migration_name[0:4]) + 1
+
+    return '%04d' % next_number
+
+
+class Command(BaseCommand):
+    help = """
+        Creates a migration to import a specific JSON file for a new page
+        into the database
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('page_url')
+        parser.add_argument('json_filepath')
+
+    def handle(self, *args, **options):
+        page_url = options['page_url']
+        json_filepath = options['json_filepath']
+
+        app_name = 'website'
+        template_filename = 'replace-page.py.jinja2'
+
+        migration_dir = os.path.join(app_name, 'migrations')
+
+        json_filename = os.path.basename(json_filepath)
+        migration_suffix = (
+            '_' + re.sub('\.[^.]+$', '', json_filename) + '_replace_page.py'
+        )
+
+        existing_migration = glob.glob(
+            os.path.join(migration_dir, '*' + migration_suffix)
+        )
+
+        previous_migration = latest_migration(migration_dir)
+        migration_prefix = next_migration_number(previous_migration)
+        output_filename = migration_prefix + migration_suffix
+
+        output_filepath = os.path.join(migration_dir, output_filename)
+        template_filepath = os.path.join(
+            app_name, 'migrations', template_filename
+        )
+
+        # Parse template
+        with open(template_filepath) as template:
+            parser = Template(template.read())
+            migration_contents = parser.render(
+                filepath=json_filepath,
+                page_url=page_url,
+                previous_migration=previous_migration
+            )
+
+        print "- Writing migration to " + output_filepath
+        # Write output
+        with open(output_filepath, 'w') as migration:
+            migration.write(migration_contents)

--- a/website/migrations/replace-page.py.jinja2
+++ b/website/migrations/replace-page.py.jinja2
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+# Modules
+from django.db import migrations
+
+# Local
+from website.models import Page
+from website.db_helpers import import_page_from_json_file
+
+
+def import_page(apps, schema_editor):
+    """
+    Import a new page from a JSON data in the "page-data" directory
+    """
+
+    Page.objects.get(url="{{ page_url }}").delete()
+
+    import_page_from_json_file('{{ filepath }}')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('website', '{{ previous_migration }}'),
+    ]
+
+    operations = [
+        migrations.RunPython(import_page)
+    ]


### PR DESCRIPTION
## QA

``` bash
make run
```

Make some changes to one of the pages in http://127.0.0.1:8010/admin.

Now create a migration to update that page:

``` bash
make replace-page  # Will prompt you to enter the page URL
```

And replace the database:

``` bash
make db-reset
```

And go and check your changes are still there on the site.
