### PR TITLE
Don't allow all origins

### DIFF
--- a/website/settings.py
+++ b/website/settings.py
@@ -11,6 +11,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'cao6_8kd&1+_k42gm0gvhx36!idz1-jexggr3^d=b=@wmxy@od'
 
 WHITENOISE_MAX_AGE = 31557600
+WHITENOISE_ALLOW_ALL_ORIGINS = False
 
 DEBUG = False
 ALLOWED_HOSTS = ["*"]


### PR DESCRIPTION
WhiteNoise [defaults to](http://whitenoise.evans.io/en/stable/django.html#WHITENOISE_ALLOW_ALL_ORIGINS) allowing all origins for all static files, which is silly. Disable it.
## QA

``` bash
make run stop  # Get database provisioned
docker-compose run web bash -c "pip install gunicorn && gunicorn -b 0.0.0.0:5000 website.wsgi"  # Run with gunicorn
```

Check headers:

``` bash
$ curl -I cn.ubuntu.com/static/css/global.css  # Check what's currently on production
...
Access-Control-Allow-Origin: *   # <--- bad website

$ curl -I 127.0.0.1:8010/static/css/global.css  # Check the new version
# Behold the lack of "Access-Control-Allow-Origin"
```
