### PR TITLE
Fix versioned_static

### DIFF
--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -7,6 +7,7 @@ psycopg2==2.6.1
 django-markdown-deux==1.0.5
 django-reversion-compare==0.5.5
 whitenoise==2.0.6
+django-static-root-finder==0.2.1
 django-versioned-static-url==0.6
 django-template-finder-view==0.2
 django-openid-auth==0.7

--- a/website/settings.py
+++ b/website/settings.py
@@ -51,6 +51,7 @@ MIDDLEWARE_CLASSES = [
 ROOT_URLCONF = 'website.urls'
 
 STATICFILES_FINDERS = [
+    'django_static_root_finder.finders.StaticRootFinder',
     "django.contrib.staticfiles.finders.AppDirectoriesFinder"
 ]
 STATIC_ROOT = 'static'


### PR DESCRIPTION
Versioned static URLs should work now.

Fixes #79

Revert "Remove django-static-root-finder"

This reverts commit 17443d0b7305b0d3f9d55be619f2e00f8f9a5e64.
## QA

```
make clean-all run
```

Visit http://127.0.0.1:8010, view source and check CSS files have ?v= strings on them.
