### PR TITLE
correct email address on IoT

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -19,7 +19,7 @@
             {% include "templates/_cms-block.html" with block_content=hero %}
         </div>
         <p><a class="link-cta-ubuntu" href="http://cn.developer.ubuntu.com/zh-cn/snappy/">开启 Ubuntu Core 的精彩之旅</a></p>
-        <p><a href="mailto:ubuntu-china@canonical.com" class="external">如果您对成品设备感兴趣，请联系我们</a></p>
+        <p><a href="mailto:chinamarketing@canonical.com" class="external">如果您对成品设备感兴趣，请联系我们</a></p>
     </div>
     <div class="four-col last-col align-center align-vertically">
         <img src="{{ STATIC_URL }}img/cloud/snappy.png" alt="Snappy logo" />


### PR DESCRIPTION
### Done

Updated an incorrect email address on IoT
### QA

Go to /internet-of-things and check that the link under the first CTA "如果您对成品设备感兴趣，请联系我们" is linking to "mailto:chinamarketing@canonical.com"
