### PR TITLE
update the h1 on ubuntu on windows news story

### DIFF
--- a/templates/news/2016/04/07/ubuntu-on-windows.html
+++ b/templates/news/2016/04/07/ubuntu-on-windows.html
@@ -1,5 +1,5 @@
 {% extends "news/base_news.html" %}
-{% block title %}Ubuntu在Windows，为Windows开发者准备的Ubuntu开发环境{% endblock %}
+{% block title %}2015年中国移动全球合作伙伴大会亮点后序{% endblock %}
 {% block content %}
 
 <div class="row row-hero no-border">


### PR DESCRIPTION
# Details

fixed the h1 with the correct title
## done
- updated the h1 with the correct title
## qa
- go to /news/ubuntu-on-windows and see the title and h1 match
