### PR TITLE
download page updates, modifications to add a class to cms-block and …

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -1,149 +1,84 @@
 body.download {
+  @media only screen and (min-width : 984px) {
+    .inner-wrapper {
+      padding-bottom: 0;
+    }
+  }
 
-	.row-zh-CN .box-highlight h2,
-	.row-zh-CN .box-highlight p {
-		padding-right: 20px;
-	}
-	.inner-wrapper form fieldset {
-		background: none;
-		margin: 0;
-		padding-left: $gutter_width;
-		padding: 0;
-	}
+  .row-zh-CN .box-highlight h2,
+  .row-zh-CN .box-highlight p {
+    padding-right: 20px;
+  }
+  .inner-wrapper form fieldset {
+    background: none;
+    margin: 0;
+    padding-left: $gutter_width;
+    padding: 0;
+  }
 
-	.inner-wrapper form button,
-	.inner-wrapper form .link-cta-download,
-	.inner-wrapper .link-cta-ubuntu {
-		@include font_size (19.5);
-		padding: 10px 14px;
-		border: 0;
-		float: left;
-		text-align: center;
-		width: 100%;
-		margin-left: 0;
-		margin-bottom: 0.615em;
-		text-decoration: none;
-	}
+  .inner-wrapper form button,
+  .inner-wrapper form .link-cta-download,
+  .inner-wrapper .link-cta-ubuntu {
+    @include font_size (19.5);
+    padding: 10px 14px;
+    border: 0;
+    float: left;
+    text-align: center;
+    width: 100%;
+    margin-left: 0;
+    margin-bottom: 0.615em;
+    text-decoration: none;
+  }
 
-	#main-content .row-background {
-		background: url("../img/backgrounds/image-background-wallpaper1404.jpg") no-repeat scroll 0 bottom #4B1827;
-		margin-top: 0;
-		padding-top: 40px;
+  #main-content .row-background {
+    background: url("../img/backgrounds/image-background-wallpaper1404.jpg") no-repeat scroll 0 bottom #4B1827;
+    margin-top: 0;
+    padding-top: 40px;
 
-		h1,
-		p {
-			color: #ffffff;
-		}
-		a:link,
-		a:visited {
-			color: #fff;
-		}
-		a:hover {
-			color: rgba(255,255,255,0.6);
-		}
+    h1,
+    p {
+      color: #ffffff;
+    }
+    a:link,
+    a:visited {
+      color: #fff;
+    }
+    a:hover {
+      color: rgba(255,255,255,0.6);
+    }
 
-		a.external {
-			background-image: url("../img/icons/icon-externallink-white.svg");
-		}
+    a.external {
+      background-image: url("../img/icons/icon-externallink-white.svg");
+    }
 
-		a.external:hover {
-			background-image: url("../img/icons/icon-externallink-warmgrey.svg");
-		}
+    a.external:hover {
+      background-image: url("../img/icons/icon-externallink-warmgrey.svg");
+    }
 
-		.box-highlight {
-			border: none;
-				-moz-box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.2);
-				-webkit-box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.2);
-   			box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.2);
-			background-color: rgba(0, 0, 0, .25);
-			color: #ffffff;
-		}
+    .box-highlight {
+      -moz-box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.2);
+      -webkit-box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.2);
+      background-color: rgba(0, 0, 0, .25);
+      border: none;
+      color: #ffffff;
+       box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.2);
+    }
 
-		.vertical-divider > div,
-		.vertical-divider > li {
-			border-color: rgba(255,255,255,0.2); /*#78515f;*/
-		}
-	}
+    .vertical-divider > div,
+    .vertical-divider > li {
+      border-color: rgba(255,255,255,0.2); /*#78515f;*/
+    }
+  }
 } // end body.download
 
-.row-community {
-	background: #fff url('../img/backgrounds/background-dots.png');
-	color: $cool_grey;
-	padding: 40px 20px 20px;
-
-	.six-col,
-	.nine-col {
-		padding: 20px;
-	}
-
-	div.six-col,
-	div.eight-col, {
-		background: rgba(255,255,255,1);
-		position: relative;
-	}
-
-	.where-to-find-us {
-	  background: #fff;
-	  margin: 0;
-	  padding: 15px 20px;
-	}
-
-	.where-to-find-us ul {
-		margin-bottom: 0;
-	}
-
-	.where-to-find-us h3 {
-		@include font_size (16);
-		border-bottom: 1px dotted $warm_grey;
-		padding-bottom: 10px;
-		margin-bottom: 10px;
-	}
-
-	.where-to-find-us li {
-		padding: 0 0 8px 26px;
-		background: url("../img/icons/icon-irc.png") 0 4px no-repeat;
-		border: none;
-		margin-bottom: 8px;
-	}
-
-	.where-to-find-us li a {
-		padding-bottom: 2px;
-	}
-
-	.where-to-find-us li:last-child {
-		margin-bottom: 0;
-		padding-bottom: 0;
-	}
-
-	.nine-col div.six-col {
-	    background: #fff;
-	    display: block;
-	}
-
-	.three-col:nth-of-type(2) {
-	    margin-right: 0;
-	}
-} //end .row-community
-
-
-/* Medium / Tablet viewport
--------------------------------------------------------------- */
 @media only screen and (min-width : 768px) {
-	.row-community {
-		margin-bottom: -10px;
+  .row-community {
+    img {
+      padding-top: 60px;
+    }
 
-		.picto {
-			margin-top: 30px;
-		}
-	}
+    .community {
+      padding-top: 65px;
+    }
+  }
 }
-// end @media only screen and (min-width : 768px)
-
-/* Large / Desktop viewport
--------------------------------------------------------------- */
-@media only screen and (min-width : 984px) {
-	.row-community {
-		margin-bottom: -20px;
-	}
-}
-// end @media only screen and (min-width : 984px)

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -17,12 +17,12 @@
     <div class="twelve-col">
         <div class="box box-highlight clearfix vertical-divider">
             <div class="eight-col no-margin-bottom">
-                {% include "templates/_cms-block.html" with block_content=lts_release %}
+                {% include "templates/_cms-block.html" with block_content=lts_release extra_classes="lts-content" %}
             </div>
             <div class="four-col last-col no-margin-bottom">
                 <p>选择版本</p>
-                <p><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/14.04.2/release/ubuntukylin-14.04.2-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '14.04 64 bit', 'From English-language Chinese download']);">64位下载键</a>
-                <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/14.04.2/release/ubuntukylin-14.04.2-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '14.04 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
+                <p><a href="http://releases.ubuntu.com/16.04/ubuntu-16.04-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">64位下载键</a>
+                <a href="http://releases.ubuntu.com/16.04/ubuntu-16.04-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">32位下载键</a></p>
                 <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
             </div>
         </div>
@@ -30,12 +30,12 @@
     <div class="twelve-col no-margin-bottom">
         <div class="box box-highlight clearfix vertical-divider">
             <div class="eight-col no-margin-bottom">
-                {% include "templates/_cms-block.html" with block_content=latest_release %}
+                {% include "templates/_cms-block.html" with block_content=latest_release extra_classes="latest-release" %}
             </div>
             <div class="four-col last-col no-margin-bottom download-button">
                 <p>选择版本</p>
-                <p><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/15.10/release/ubuntukylin-15.10-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '15.10 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
-                <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/15.10/release/ubuntukylin-15.10-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '15.10 32 bit', 'From English-language Chinese download']);">下载32位镜像</a></p>
+                <p><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-amd64.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 64 bit', 'From English-language Chinese download']);">下载64位镜像</a>
+                <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04-desktop-i386.iso" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '16.04 32 bit', 'From English-language Chinese download']);">下载32位镜像</a></p>
                 <p><span class="clearfix smaller">(如果你电脑的内存少于2GB,选择32位下载)</span></p>
             </div>
         </div>
@@ -44,31 +44,34 @@
 
 <div class="row">
     <div class="eight-col">
-        {% include "templates/_cms-block.html" with block_content=other_downloads %}
+        {% include "templates/_cms-block.html" with block_content=other_downloads extra_classes="other-downloads" %}
     </div>
     <div class="equal-height">
-        <div class="box four-col">
-            {% include "templates/_cms-block.html" with block_content=cloud %}
+        <div class="box six-col">
+            {% include "templates/_cms-block.html" with block_content=alternative_1 extra_classes="alternative-1" %}
         </div>
-        <div class="box four-col">
-            {% include "templates/_cms-block.html" with block_content=server %}
+        <div class="box six-col last-col">
+            {% include "templates/_cms-block.html" with block_content=alternative_2 extra_classes="alternative-2" %}
         </div>
-        <div class="box four-col last-col">
-            {% include "templates/_cms-block.html" with block_content=desktop %}
+        <div class="box six-col">
+            {% include "templates/_cms-block.html" with block_content=cloud extra_classes="cloud" %}
+        </div>
+        <div class="box six-col last-col">
+            {% include "templates/_cms-block.html" with block_content=server extra_classes="server" %}
         </div>
     </div>
 </div>
 
-<div class="row row-community no-border">
-    <div class="three-col text-center no-margin">
+<div class="row row-community row-grey no-border">
+    <div class="three-col text-center">
         <img class="picto" src="{{ STATIC_URL }}img/pictograms/picto-pack/picto-community-orange.svg" alt="" width="150" height="150" />
     </div>
     <div class="nine-col last-col">
         <div class="six-col">
-            {% include "templates/_cms-block.html" with block_content=community %}
+            {% include "templates/_cms-block.html" with block_content=community  extra_classes="community" %}
         </div>
         <div class="three-col last-col box where-to-find-us smaller">
-            {% include "templates/_cms-block.html" with block_content=community_links %}
+            {% include "templates/_cms-block.html" with block_content=community_links extra_classes="community-links" %}
         </div>
     </div>
 </div>

--- a/templates/templates/_cms-block.html
+++ b/templates/templates/_cms-block.html
@@ -1,5 +1,5 @@
 
 {% load markdown_deux_tags %}
-<div class="cms-content">
+<div class="cms-content {{ extra_classes }}">
     {{ block_content | markdown }}
 </div>


### PR DESCRIPTION
…killed the special style for community
### Done:
- Updated CMS blocks - note, that your DB won't have the requisite content block
- Drive-by fix for tabbing - review without whitespace changes
- Removed the custom styling for row-community
### QA

Load `/download`
Check the download links against the copydocs but the content will not be updated.
Also check the layout of the community row.
### Copydoc

https://docs.google.com/document/d/1b8pXcsMPTzu5dXiG7qKBSvYzwV1aawQ12M4mzsOnQfM/edit
