### PR TITLE
add support for some CMS content blocks having CTA buttons

### DIFF
--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -145,3 +145,38 @@ body.desktop {
     }
   }
 }
+
+// CMS content-specific
+.cta-links a {
+  -webkit-box-sizing:border-box;
+  -moz-box-sizing:border-box;
+  box-sizing:border-box;
+  font-size:1.14286em;
+  margin-bottom:.75em;
+  -webkit-border-radius:3px;
+  -moz-border-radius:3px;
+  border-radius:3px;
+  background:#dd4814;
+  color:#fff;
+  text-decoration:none;
+  display:inline-block;
+  margin:0;
+  font-family:ubuntulight,Ubuntu,Arial,'libra sans',sans-serif;
+  font-weight:300;
+  -webkit-font-smoothing:subpixel-antialiased;
+  -moz-font-smoothing:subpixel-antialiased;
+  -o-font-smoothing:subpixel-antialiased;
+  font-smoothing:subpixel-antialiased;
+  padding:8px 14px;
+  width:100%;
+  text-align:center;
+
+  @media only screen and (min-width : 768px) {
+    width: auto;
+  }
+
+  &:hover {
+    background:#c03f11;
+    text-decoration:none;
+  }
+}

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -16,7 +16,7 @@
 {% if hero %}
 <div id="ubuntu-kyin" class="row row-hero">
     <div class="six-col">
-        {% include "templates/_cms-block.html" with block_content=hero %}
+        {% include "templates/_cms-block.html" with block_content=hero extra_classes="cta-links" %}
     </div>
 </div>
 {% endif %}
@@ -51,7 +51,7 @@
             {% include "templates/_cms-block.html" with block_content=for_business %}
         </div>
         <div class="four-col last-col for-developers">
-            {% include "templates/_cms-block.html" with block_content=for_developers %}
+            {% include "templates/_cms-block.html" with block_content=for_developers extra_classes="cta-links" %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Done

Added an override for some CMS content blocks to turn all links to CTAs
### QA
- `make run`
- Go to /admin
- add a markdown link to the "hero" and "for_developers" blocks - `[like this](http://example.com)`
- Check /desktop and see that the links in those two sections are now CTAs
- Congratulate me for such great work
