### PR TITLE
fix for overflow and footer padding

### DIFF
--- a/static/css/_scratch.scss
+++ b/static/css/_scratch.scss
@@ -179,10 +179,10 @@ footer #nav-global {
   -webkit-box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.3) inset;
   box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.3) inset;
   display: block;
-  margin-bottom: 10px;
   margin-top: 0;
   margin: 0 -10px;
   overflow: hidden;
+  padding-bottom: 10px;
   padding-top: 0;
 
   div {
@@ -350,6 +350,10 @@ footer #nav-global {
     margin: 0;
     padding: 0;
   }
+}
+
+footer.global {
+  overflow: hidden;
 }
 
 /* Medium / Tablet viewport


### PR DESCRIPTION
### done

Small design tweaks for footer:
- added 10px to above the footer links in small screen
- stopped footer.glboal's content from overflowing at medium screen and causing a horizontal scroll
### QA

Check that the footer looks good at all viewports.
