### PR TITLE
Use re path 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ env[23]/
 # Ignore created directory
 /static/js
 
+.webcache/

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, include
+from django.urls import re_path, path, include
 from canonicalwebteam.django_views import TemplateFinder
 from canonicalwebteam.yaml_responses.django_helpers import (
     create_redirect_views,
@@ -7,6 +7,6 @@ from canonicalwebteam.yaml_responses.django_helpers import (
 urlpatterns = create_redirect_views()
 urlpatterns += [
     path(r"blog", include("canonicalwebteam.blog.django.urls")),
-    path(r"<template>", TemplateFinder.as_view()),
+    re_path(r"^(?P<template>.*)$", TemplateFinder.as_view()),
     path(r"", TemplateFinder.as_view()),
 ]


### PR DESCRIPTION
## Done

Use `re_path` for urls defined as regex in `urls.py` 
https://docs.djangoproject.com/en/2.2/ref/urls/#re-path

Add .webcache to gitginore in the same PR

## QA

- `./run`
- http://127.0.0.1:8010/engage/robot-operating-system-choice-cn
- Page should be accessible
- Navigate in the site and make sure other templates work

## Issue / Card

Fixes https://github.com/canonical-web-and-design/cn.ubuntu.com/issues/313
