### PR TITLE
Updates blog module to 1.3.5 to fix 404 on article pages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2
-canonicalwebteam.blog==1.3.4
+canonicalwebteam.blog==1.3.5
 canonicalwebteam.http==1.0.1
 canonicalwebteam.versioned-static==1.0.2
 canonicalwebteam.yaml-responses[django]==1.1.0


### PR DESCRIPTION
## Done

- Update blog module to 1.3.5 to include https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/32


## QA

- `./run`
- go to `hhttp://localhost:8010/blog/canonical-at-open-infrastructure-summit-denver` and make sure it displays (is english content, and not chinese)
