### PR TITLE
Set the max-width of the global-nav

### DIFF
--- a/static/js/global-nav.js
+++ b/static/js/global-nav.js
@@ -1,3 +1,3 @@
 import { createNav } from "@canonical/global-nav";
 
-createNav({ maxWidth: "64.875rem" });
+createNav({ maxWidth: "72rem" });


### PR DESCRIPTION
## Done
Set the max-width of the global-nav

## QA
- Load the demo
- Check the Canonical logo in the global nav aligns with the Ubuntu logo below.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/cn.ubuntu.com/issues/331

## Screenshots
![Screenshot_2019-07-12 Ubuntu中国官网, IoT物联网, 服务器和云端的领先开源操作系统 Ubuntu](https://user-images.githubusercontent.com/1413534/61132189-c7849680-a4b2-11e9-9056-7f8651dbd1d1.png)

