### PR TITLE
Add social metadata to site

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -1,5 +1,11 @@
-{% extends "templates/base.html" %}
+{% extends_with_args "templates/base.html" with title=article.title.rendered meta_description=article.excerpt.raw  meta_image=article.image.source_url %}
+
 {% block title %}{{article.title.rendered|safe}}{% endblock %}
+
+{% block meta_description %}{{ article.excerpt.raw | striptags }}{% endblock %}
+
+{% block meta_image %}{{ article.image.source_url }}{% endblock %}
+
 {% block content %}
 <section id="main-content" class="p-strip">
   <div class="row">

--- a/templates/engage/robot-operating-system-choice-cn.html
+++ b/templates/engage/robot-operating-system-choice-cn.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}Extended Security Maintenance (ESM) will be available for Ubuntu 14.04 LTS Trusty Tahr after End of Life for continued security and compliance of the most popular linux operating system.{% endblock %}
-
-{% block title %}选择最合适的机器人操作系统{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="选择最合适的机器人操作系统" meta_image="https://assets.ubuntu.com/v1/5f75154f-bot.png" meta_description="Extended Security Maintenance (ESM) will be available for Ubuntu 14.04 LTS Trusty Tahr after End of Life for continued security and compliance of the most popular linux operating system." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1zAv3ouUrzQcQDw2DSefaePXcMu35BAumIMpzqmIkycs/edit{% endblock meta_copydoc %}
 
@@ -12,7 +8,7 @@
   .p-takeover--robotics {
     background-color: #262626;
   }
-  
+
   .p-takeover--robotics .p-takeover__title {
     font-weight: 100;
     color: #ffffff;
@@ -113,7 +109,7 @@
 
     </div>
     <div class="col-5">
-   
+
     <!-- MARKETO FORM -->
 <script src="//assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
 <script src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
@@ -159,7 +155,7 @@
       </li>
       <li class="mktField">
         <br />
-      </li>  
+      </li>
       <li class="mktField">
         <button type="submit" class="mktoButton u-no-margin--bottom">下载白皮书</button>
         <input name="formid" aria-label="formid" class="mktoField" value="3346" type="hidden">
@@ -204,7 +200,7 @@
 
     </div>
 
-    
+
   </div>
 </section>
 

--- a/templates/templates/_extra_metadata.html
+++ b/templates/templates/_extra_metadata.html
@@ -1,0 +1,20 @@
+<meta name="theme-color" content="#E95420" />
+<meta name="twitter:account_id" content="4503599627481511" />
+<meta name="twitter:site" content="@ubuntu">
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://cn.ubuntu.com{{ request.get_full_path }}" />
+<meta property="og:site_name" content="Ubuntu" />
+
+{% if title %}
+    <meta name="twitter:title" content="{{ title }} | Ubuntu">
+    <meta property="og:title" content="{{ title }} | Ubuntu" />
+{% endif %}
+{% if meta_description %}
+    <meta name="twitter:description" content="{{ meta_description }}">
+    <meta property="og:description" content="{{ meta_description }}" />
+{% endif %}
+{% if meta_image %}
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="{% if "http" not in meta_image %}{{ ASSET_SERVER_URL }}{% endif %}{{ meta_image }}">
+    <meta property="og:image" content="{% if "http" not in meta_image %}{{ ASSET_SERVER_URL }}{% endif %}{{ meta_image }}" />
+{% endif %}

--- a/templates/templates/_extra_metadata.html
+++ b/templates/templates/_extra_metadata.html
@@ -1,20 +1,20 @@
-<meta name="theme-color" content="#E95420" />
-<meta name="twitter:account_id" content="4503599627481511" />
-<meta name="twitter:site" content="@ubuntu">
-<meta property="og:type" content="website" />
-<meta property="og:url" content="https://cn.ubuntu.com{{ request.get_full_path }}" />
-<meta property="og:site_name" content="Ubuntu" />
+  <meta name="theme-color" content="#E95420" />
+  <meta name="twitter:account_id" content="4503599627481511" />
+  <meta name="twitter:site" content="@ubuntu">
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://cn.ubuntu.com{{ request.get_full_path }}" />
+  <meta property="og:site_name" content="Ubuntu" />
 
-{% if title %}
-    <meta name="twitter:title" content="{{ title }} | Ubuntu">
-    <meta property="og:title" content="{{ title }} | Ubuntu" />
-{% endif %}
-{% if meta_description %}
-    <meta name="twitter:description" content="{{ meta_description }}">
-    <meta property="og:description" content="{{ meta_description }}" />
-{% endif %}
-{% if meta_image %}
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="{% if "http" not in meta_image %}{{ ASSET_SERVER_URL }}{% endif %}{{ meta_image }}">
-    <meta property="og:image" content="{% if "http" not in meta_image %}{{ ASSET_SERVER_URL }}{% endif %}{{ meta_image }}" />
-{% endif %}
+  {% if title %}
+  <meta name="twitter:title" content="{{ title }} | Ubuntu">
+  <meta property="og:title" content="{{ title }} | Ubuntu" />
+  {% endif %}
+  {% if meta_description %}
+  <meta name="twitter:description" content="{{ meta_description }}">
+  <meta property="og:description" content="{{ meta_description }}" />
+  {% endif %}
+  {% if meta_image %}
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="{% if "http" not in meta_image %}{{ ASSET_SERVER_URL }}{% endif %}{{ meta_image }}">
+  <meta property="og:image" content="{% if "http" not in meta_image %}{{ ASSET_SERVER_URL }}{% endif %}{{ meta_image }}" />
+  {% endif %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -12,10 +12,10 @@
   <!-- End Google Tag Manager -->
 
   <meta charset="UTF-8" />
-  <meta name="description" content="{% block meta_description %}Ubuntu是世界领先的开源操作系统。目前广泛应用于个人电脑，IoT/智能物联网，容器，服务器和云端上。{% endblock %}" />
+  <meta name="description" content="{% block meta_description %}{{ meta_description | default:"Ubuntu是世界领先的开源操作系统。目前广泛应用于个人电脑，IoT/智能物联网，容器，服务器和云端上。"}}{% endblock %}" />
   <meta name="author" content="Canonical" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{% block title %}{% endblock %} | Ubuntu</title>
+  <title>{% block title %}{{ title }}{% endblock %} | Ubuntu</title>
   <link rel="shortcut icon" href="/static/img/favicon.ico" type="image/x-icon" />
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/static/img/apple-touch-icon-144x144-precomposed.png">
   <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/static/img/apple-touch-icon-114x114-precomposed.png">
@@ -23,7 +23,7 @@
   <link rel="apple-touch-icon-precomposed" href="/static/img/apple-touch-icon-precomposed.png">
   <link type="text/plain" rel="author" href="{% versioned_static 'files/humans.txt' %}" />
   <link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'css/styles.css' %}" />
-
+  {% include "templates/_extra_metadata.html" %}
 
   {% block head_extra %}{% endblock %}
 </head>

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -45,10 +45,11 @@ TEMPLATES = [
         "DIRS": ["templates"],
         "APP_DIRS": True,
         "OPTIONS": {
+            "builtins": ["webapp.templatetags.utils"],
             "context_processors": [
                 "django_asset_server_url.asset_server_url",
                 "django.template.context_processors.request",
-            ]
+            ],
         },
     }
 ]

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -1,0 +1,54 @@
+from django import template
+from django.template.loader_tags import do_extends
+
+register = template.Library()
+
+
+class ExtendsWithArgsNode(template.Node):
+    def __init__(self, node, arguments):
+        self.node = node
+        self.arguments = arguments
+
+    def render(self, context):
+        extra_context = {}
+
+        for item in self.arguments:
+            if "=" not in item:
+                continue
+
+            key, value = item.split("=")
+
+            if value == "":
+                extra_context[key] = value
+            elif value[0] in ('"', "'") and value[-1] in ('"', "'"):
+                # It's a string
+                extra_context[key] = value[1:-1]
+            else:
+                # It's a variable
+                try:
+                    variable = template.Variable(value)
+                    extra_context[key] = variable.resolve(context)
+                except template.VariableDoesNotExist:
+                    extra_context[key] = ""
+
+        context.update(extra_context)
+        self.node.origin = self.origin
+        return self.node.render(context)
+
+
+@register.tag
+def extends_with_args(parser, token):
+    """
+    Parse extends_with_args extension declarations.
+    Arguments are made available in context to the extended template
+    and its includes.
+    E.g.:
+
+    {% extends_with_args "base.html" foo="bar" baz="toto" %}
+    """
+
+    all_arguments = token.split_contents()
+    token.contents = " ".join(all_arguments[:2])
+
+    # Use do_extends to parse the tag
+    return ExtendsWithArgsNode(do_extends(parser, token), all_arguments[2:])


### PR DESCRIPTION
## Done

- Add extend_with_args to the cn.u.c site for blog posts, engage, etc...

## QA

- Download this PR
- ./run the site
- Look at head of and [engage page](http://0.0.0.0:8010/engage/robot-operating-system-choice-cn) and a [blog post](http://0.0.0.0:8010/blog/ubuntu-5g-bt) and see they have the twitter/opengraph info

## Issue / Card

Fixes #333


