### PR TITLE
Reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -85,9 +85,16 @@ package.json
 node_modules
 yarn.lock
 
+# Environemnt
+.env
+.env.local
+
 # Git, travis, docker
 .git
 .gitignore
+.github
+.circleci
+.codecov
 .travis.yml
 docker-compose.yml
 .docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,17 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # System dependencies
-RUN apt-get update && apt-get install --yes python3-pip
+RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip
 
 # Import code, install code dependencies
-ADD . .
-RUN pip3 install -r requirements.txt
+COPY . .
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 # Set git commit ID
 ARG COMMIT_ID
 RUN test -n "${COMMIT_ID}"
-RUN echo "${COMMIT_ID}" > version-info.txt
+ENV COMMIT_ID "${COMMIT_ID}"
+ENV TALISKER_REVISION_ID "${COMMIT_ID}"
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]


### PR DESCRIPTION
Reduce size of docker image

## QA
- on `master` run `docker build --build-arg COMMIT_ID=test -t cn.ubuntu.com:master . `
- checkout this feature branch
- run `docker build --build-arg COMMIT_ID=test -t cn.ubuntu.com:feature .`
- run `docker images` and see the image tagged as `feature` is smaller than `master`
- run `docker run -ti -p 8010:80 cn.ubuntu.com:feature`
- browse localhost:8010 and make sure the site works