### PR TITLE
multi-takeover & Desktop WP

### DIFF
--- a/templates/engage/developer-desktop.html
+++ b/templates/engage/developer-desktop.html
@@ -1,0 +1,154 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}开发者选择Ubuntu桌面的六大理由{% endblock %}
+{% block meta_description %}最流行的linux os操作系统，开放者选择Ubuntu的六大理由{% endblock %}
+{% block meta_image %}https://assets.ubuntu.com/v1/a68a11b7-Dell+XPS+13-1804-1.png{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1bqD9QKDj6ZfRkn-vbDrHHE_Zrk81cA5hFLRHZYFzzSA{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip p-takeover--developer-desktop">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-7 u-vertically-center">
+      <h1 class="p-takeover__title">开发者选择Ubuntu桌面的六大理由</h1>
+    </div>
+    <div class="col-5 u-vertically-center ">
+      <div class="u-align-text--center u-hide--small">
+        <img src="https://assets.ubuntu.com/v1/a68a11b7-Dell+XPS+13-1804-1.png?w=413" width="413" alt="Dell XPS laptop for developers running Ubuntu Desktop by default"/>
+      </div>
+      <p class="u-hide--medium u-hide--large ">
+        <a href="#the-form" class="p-button--positive"> 下载白皮书 </a>
+      </p>
+    </div>
+  </div>
+
+  <style>
+    .p-takeover--developer-desktop {
+      background-image: linear-gradient(74deg, #2C3037 0%, #1E1E1E 100%);
+      background-color: #2C3037;
+      background-size: cover;
+    }
+    .p-takeover--developer-desktop .p-takeover__title {
+      font-weight: 100;
+      color: #ffffff;
+      margin-bottom: 1rem;
+    }
+  </style>
+</section>
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>全球排名第一的Linux操作系统（OS）Ubuntu桌面已被240多个国家/地区的政府，企业和消费者广泛使用。Ubuntu适用于各种应用程序（如机器人技术，人工智能，全栈Web开发和嵌入式设备）开发且具有强大的吸引力，很多技术领先的公司都在使用Ubuntu。</p>
+
+        <div class="u-align--center col-12 u-hide--small">
+              <img src="https://assets.ubuntu.com/v1/9406095a-Screenshot+from+2018-11-23+12-29-32.png?h=230" height="230" style="height:230px;" alt="Developers use Ubuntu all around the world">
+        </div>
+        <p>但是为什么如此受欢迎？ 本白皮书分析了开发人员转向Ubuntu的六个关键原因。 从AI，机器学习兴起到更安全的snap应用，开发者对Ubuntu的使用不断增加。</p>
+        <h3>白皮书亮点：</h3>
+        <ul class="p-list">
+            <li class="p-list__item is-ticked">无论是产品开始，还是平台端选择（云、服务器、IoT设备），Ubuntu桌面都是理想的平台。</li>
+            <li class="p-list__item is-ticked">Ubuntu社区提供了广泛的支持和知识库，更广泛的Linux生态系统和Canonical企业支持服务<a href="https://cn.ubuntu.com/blog/how-to-buy-ubuntu-subscription">Ubuntu Advantage</a> 。</li>
+            <li class="p-list__item is-ticked">广泛的软硬件兼容性认证使得开发过程更畅通无阻。</li>
+        </ul>
+
+
+    </div>
+    <div class="col-5">
+
+      <!-- MARKETO FORM -->
+<script src="https://assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
+<script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+<script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3488" style="margin-top: -1rem;" novalidate="novalidate">
+ <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+   <ul class="p-list">
+     <li class="mktFormReq mktField p-list__item">
+       <label for="FirstName" class="mktoLabel">名字：</label>
+       <input required="" id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="First Name" aria-required="true">
+     </li>
+     <li class="mktFormReq mktField">
+       <label for="LastName" class="mktoLabel ">姓氏：</label>
+       <input required="" id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Last Name" aria-required="true">
+     </li>
+     <li class="mktFormReq mktField">
+       <label for="Email" class="mktoLabel ">工作邮箱：</label>
+       <input required="" id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" aria-label="Email" aria-required="true">
+     </li>
+     <li class="mktFormReq mktField">
+       <label for="Company" class="mktoLabel ">公司名称：</label>
+       <input required="" id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name" aria-required="true">
+     </li>
+     <li class="mktFormReq mktField">
+       <label for="Title" class="mktoLabel ">职位：</label>
+       <input required="" id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title" aria-required="true">
+     </li>
+     <li class="mktFormReq mktField">
+       <label for="Phone" class="mktoLabel ">电话号码：</label>
+       <input required="" id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel" aria-label="Phone Number" aria-required="true">
+     </li>
+     <li class="mktField">
+      <p>在提交此表格的同时，我确认已阅读和同意<a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy/contact">Canonical的隐私声明</a>和<a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy">隐私政策</a>。
+        <input name="RichText" aria-label="RichText" type="hidden">
+      </p>
+    </li>
+     <li class="mktField">
+       <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="None" type="hidden">
+     </li>
+     <li class="mktField">
+       <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="None" type="hidden">
+     </li>
+     <li class="mktField">
+       <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="None" type="hidden">
+     </li>
+     <li class="mktField">
+       <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+     </li>
+     <li class="mktField">
+       <br />
+     </li>
+     <li class="mktField">
+       <button type="submit" class="mktoButton u-no-margin--bottom">下载白皮书</button>
+       <input name="formid" aria-label="formid" class="mktoField" value="3488" type="hidden">
+       <input name="lpId" aria-label="lpId" class="mktoField " value="" type="hidden">
+       <input name="subId" aria-label="subId" class="mktoField " value="" type="hidden">
+       <input name="munchkinId" aria-label="munchkinId" class="mktoField " value="" type="hidden">
+       <input name="lpurl" aria-label="lpurl" class="mktoField " value="" type="hidden">
+       <input name="cr" aria-label="cr" class="mktoField " value="" type="hidden">
+       <input name="kw" aria-label="kw" class="mktoField " value="" type="hidden">
+       <input name="q" aria-label="q" class="mktoField " value="" type="hidden">
+     </li>
+   </ul>
+ </fieldset>
+ <input type="hidden" name="returnURL" aria-label="returnURL" value="https://cn.ubuntu.com/engage/thank_you_dd.html">
+ <input type="hidden" name="retURL" aria-label="retURL" value="https://cn.ubuntu.com/engage/thank_you_dd.html">
+</form>
+<script>
+ $("#mktoForm_3488").validate({
+   errorElement: "span",
+   errorClass: "mktFormMsg mktError",
+   onkeyup: false,
+   onclick: false,
+   onblur: false
+ });
+ $(function () {
+   $("#comments").hide()
+ });
+ $('#Ubuntu_User__c').on('change', function () {
+   var selection = $(this).val();
+   if (selection == 'Commercially only') {
+     $('#comments').show();
+   } else {
+     $('#comments').hide();
+   }
+ });
+</script>
+<script src="https://assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
+
+<!-- /MARKETO FORM -->
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/thank_you_dd.html
+++ b/templates/engage/thank_you_dd.html
@@ -1,0 +1,24 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}Ubuntu 16.04下载, Ubuntu 18.04下载, Ubuntu服务器下载， Ubuntu系统下载， Ubuntu中文官网， Ubuntu OpenStack, MicroK8s, Ubuntu容器{% endblock %}
+
+{% block title %}将Ubuntu桌面与Active Directory集成{% endblock %}
+
+{% block content %}
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+       <h1 class="p-heading--two">谢谢！</h1>
+       <h3>你的白皮书现已可下载...</h3>
+       <p><a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Desktop_Developers_WP_Canonical_Final%20-%20CN%20v2.pdf" class="link-cta-ubuntu cta-large" target="download">立即下载</a></p>
+    </div>
+    <div class="col-4 u-align-center u-vertically-center">
+       <img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Devices-Thankyou.svg" width="200" height="200">
+    </div>
+  </div>
+</div>
+
+
+
+{% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,48 +6,42 @@
 
 {% block page_content %}
 
-<section class="p-strip--dark p-takeover js-takeover">
-  <div class="row u-clearfix u-vertically-center">
-    <div class="col-7 ">
-      <h1>
-        将Ubuntu桌面与Microsoft Active Directory集成
-      </h1>
-      <h4 class="p-heading--four">
-        手把手教你将 Ubuntu 桌面系统加入到 Active Directory 域。
-      </h4>
-      <a href="/engage/microsoft-active-directory.html?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Desktop_Whitepaper_ActiveDirectory" class="p-button--positive u-hide--small">
-        <span>下载白皮书</span>
-      </a>
-    </div>
-    <div class="col-5">
-      <p class="u-align--center u-vertically-center">
-        <img
-          src="https://assets.ubuntu.com/v1/563fa732-ubuntu+and+active+directory.svg"
-          alt="ubuntu and active directory"
-        />
+ <!-- Section 1: Hero -->
+ <template id="takeovers" class="u-hide">
+  {% include "takeovers/_desktop-developer-takeover.html" %}
+  {% include "takeovers/_active-directory-takeover.html" %}
+</template>
+
+<section data-lang="all" id="takeover" class="p-strip--image is-dark is-deep js-takeover p-takeover--desktop-developer">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1>开发者选择Ubuntu桌面的六大理由</h1>
+      <p class="p-heading--four">探索Ubuntu桌面是如何成为产品开发的首选操作系统。</p>
+      <p class="u-hide--small">
+        <a href="/engage/developer-desktop" class="p-button--positive u-no-margin--bottom">前往下载白皮书</a>
       </p>
     </div>
-    <p class="u-hide--medium u-hide--large">
-      <a href="/engage/microsoft-active-directory.html?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Desktop_Whitepaper_ActiveDirectory" class="p-button--positive">
-        <span>下载白皮书</span>
-      </a>
-    </p>
+    <div class="col-5 u-vertically-center">
+      <div class="u-align--center u-sv3">
+        <img src="https://assets.ubuntu.com/v1/b4b238f8-Dell+XPS+13-1804-1.png" class="p-takeover-desktop-developer__image" alt="desktop" />
+      </div>
+      <p class="u-no-margin--bottom u-hide--large u-hide--medium">
+        <a href="/engage/developer-desktop" class="p-button--positive">前往下载白皮书</a>
+      </p>
+    </div>
   </div>
+
   <style>
-    .p-takeover {
-      background-image: url("https://assets.ubuntu.com/v1/e6a2c401-suru-left.svg"),
-      url("https://assets.ubuntu.com/v1/a9dab044-suru-right.svg"),
-      linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
-      background-position: left, right;
-      background-repeat: no-repeat, no-repeat;
-      background-size: auto 100%, auto 100%, cover;
-    }
-    @media (max-width: 874px) {
-      .p-takeover {
-        background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+      .p-takeover--desktop-developer {
+        background-color: #333333;
+				background-image: linear-gradient(225deg, #333333 0%, #111111 50%, #111111 100%);
       }
-    }
-  </style>
+      @media only screen and (min-width: 460px) and (max-width: 896px)  {
+        .p-takeover--desktop-developer .u-align--center {
+					text-align: left !important;
+        }
+      }
+    </style>
 </section>
 
 <section class="p-strip is-deep is-bordered">
@@ -171,5 +165,73 @@
     </div>
   </div>
 </section>
+
+<script>
+  function getPrimaryParentLanguage() {
+    /**
+      * Get the primary parent language
+      *
+      * Get the user's default language, and if it's a sub-language,
+      * infer the parent language - e.g. for "en-GB", infer "en"
+      */
+    var language = navigator.language || navigator.userLanguage || navigator.browserLanguage || navigator.systemLanguage;
+    if (language.indexOf('-') !== -1 ) {
+      language = language.split('-')[0];
+    }
+    return language
+  };
+  // get the users language and remove any extra detail suffix (e.g. -gb)
+  var language = getPrimaryParentLanguage();
+  // get notices matching the user language
+  var notices = document.querySelectorAll(".notice[lang=" + language + "]");
+  // display only one matching notice
+  if (notices.length > 0) {
+    notices[0].classList.remove("u-hide")
+  }
+  if (window.localStorage && window.sessionStorage) {
+    /**
+      * Choose a takeover
+      * ===
+      *
+      * From the list of provided takeovers in the #takeovers template,
+      * choose one (that matches the client's language), and replace the
+      * base template with it.
+      */
+    var baseTakeover = document.getElementById('takeover');  // The base takeover element
+    var takeovers = document.getElementById('takeovers');  // The list of current takeovers to choose from
+    // For browsers that support <template> (all but IE), grab the template's ".content"
+    takeovers = 'content' in takeovers ? takeovers.content: takeovers;
+    // First, select takeovers that don't specify a language and don't exclude the users language
+    var takeoverSelectors = [".js-takeover:not([lang]).js-takeover:not([lang-skip*=" + language + "])"]
+    // Add selectors to find takeovers for any of the user's languages
+    takeoverSelectors.push(".js-takeover[lang=" + language + "]");
+    takeoverSelectors.push(".js-takeover[data-lang-extra*=" + language + "]");
+    // Get the selected takeovers
+    var selectedTakeovers = (takeovers.querySelectorAll(takeoverSelectors.join(',')));
+    if (selectedTakeovers) {
+      var selectedIndex = null;
+      if (localStorage.getItem('selected_takeover_index') !== null) {
+        // If we previously chose a takeover, increment the number to show the next takeover
+        var nextIndex = parseInt(localStorage.getItem('selected_takeover_index')) + 1
+        selectedIndex = nextIndex < selectedTakeovers.length ? nextIndex : 0;
+      } else {
+        // Otherwise, randomly choose one of the takeovers and store it for next time
+        selectedIndex = Math.floor(Math.random() * selectedTakeovers.length);
+      }
+      // Store the current takeover
+      localStorage.setItem('selected_takeover_index', selectedIndex)
+      // Get the takeover element
+      var selectedTakeover = selectedTakeovers[selectedIndex]
+      if (! document.body.contains(selectedTakeover)) {
+        // If it's not in the current document (as in, it's in a template) import it
+        // Note: This is for all browser *except* IE, which doesn't support <template>s
+        selectedTakeover = document.importNode(selectedTakeover, true);
+      }
+      // Replace the base takeover with the new one
+      // Note: We can't use Node.replaceWith (which would be nice), as it's not supported in IE
+      baseTakeover.parentNode.replaceChild(selectedTakeover, baseTakeover)
+    }
+  }
+</script>
 
 {% endblock page_content %}

--- a/templates/takeovers/_active-directory-takeover.html
+++ b/templates/takeovers/_active-directory-takeover.html
@@ -1,0 +1,43 @@
+<section class="p-strip--dark p-takeover js-takeover">
+  <div class="row u-clearfix u-vertically-center">
+    <div class="col-7 ">
+      <h1>
+        将Ubuntu桌面与Microsoft Active Directory集成
+      </h1>
+      <h4 class="p-heading--four">
+        手把手教你将 Ubuntu 桌面系统加入到 Active Directory 域。
+      </h4>
+      <a href="/engage/microsoft-active-directory.html?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Desktop_Whitepaper_ActiveDirectory" class="p-button--positive u-hide--small">
+        <span>下载白皮书</span>
+      </a>
+    </div>
+    <div class="col-5">
+      <p class="u-align--center u-vertically-center">
+        <img
+          src="https://assets.ubuntu.com/v1/563fa732-ubuntu+and+active+directory.svg"
+          alt="ubuntu and active directory"
+        />
+      </p>
+    </div>
+    <p class="u-hide--medium u-hide--large">
+      <a href="/engage/microsoft-active-directory.html?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Desktop_Whitepaper_ActiveDirectory" class="p-button--positive">
+        <span>下载白皮书</span>
+      </a>
+    </p>
+  </div>
+  <style>
+    .p-takeover {
+      background-image: url("https://assets.ubuntu.com/v1/e6a2c401-suru-left.svg"),
+      url("https://assets.ubuntu.com/v1/a9dab044-suru-right.svg"),
+      linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+      background-position: left, right;
+      background-repeat: no-repeat, no-repeat;
+      background-size: auto 100%, auto 100%, cover;
+    }
+    @media (max-width: 874px) {
+      .p-takeover {
+        background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+      }
+    }
+  </style>
+</section>

--- a/templates/takeovers/_desktop-developer-takeover.html
+++ b/templates/takeovers/_desktop-developer-takeover.html
@@ -1,0 +1,31 @@
+<section class="p-strip--image is-dark is-deep js-takeover p-takeover--desktop-developer">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1>开发者选择Ubuntu桌面的六大理由</h1>
+      <p class="p-heading--four">探索Ubuntu桌面是如何成为产品开发的首选操作系统。 </p>
+      <p class="u-hide--small">
+        <a href="/engage/developer-desktop" class="p-button--positive u-no-margin--bottom">前往下载白皮书</a>
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center">
+      <div class="u-align--center u-sv3">
+        <img src="https://assets.ubuntu.com/v1/b4b238f8-Dell+XPS+13-1804-1.png" class="p-takeover-desktop-developer__image" alt="" />
+      </div>
+      <p class="u-no-margin--bottom u-hide--large u-hide--medium">
+        <a href="/engage/developer-desktop?" class="p-button--positive">前往下载白皮书</a>
+      </p>
+    </div>
+  </div>
+
+  <style>
+      .p-takeover--desktop-developer {
+        background-color: #333333;
+				background-image: linear-gradient(225deg, #333333 0%, #111111 50%, #111111 100%);
+      }
+      @media only screen and (min-width: 460px) and (max-width: 896px)  {
+        .p-takeover--desktop-developer .u-align--center {
+					text-align: left !important;
+        }
+      }
+    </style>
+</section>


### PR DESCRIPTION
## Done

Merge the takeovers js code from jp.ubuntu.com for multi-takeovers. (now 2 takeovers)
Change the main page code and load takeover template. 
Create the new engage page for Desktop dev whitepaper campaign.

