### PR TITLE
Fix node version failing with postcss

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: canonicalwebteam/dev
+    - image: canonicalwebteam/dev:v1.6.7
 
 jobs:
   lint-python:


### PR DESCRIPTION
## Done

So the staging build is failing. This is because we have updated the postcss-cli to a major version 7, and this is requiring a higher node version. I changed the docker image so that it can support this, but if this doesn't work we may need to revert the postcss-cli to a previous version.