### PR TITLE
Fix 404s

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -427,73 +427,73 @@
   <div class="row">
     <ul class="p-list row">
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/hadoop/" class="p-link--soft">
+          <a href="https://jaas.ai/hadoop-spark/bundle/63" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/0c2c6e40-hadoop-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">Hadoop</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/mongodb/" class="p-link--soft">
+          <a href="https://jaas.ai/mongodb" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/d529fc0b-mongodb-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">MongoDB</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/u/asanjar/spark/" class="p-link--soft">
+          <a href="https://jaas.ai/u/asanjar/spark/trusty/7" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/da65dfb1-spark-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">Spark</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/redis/" class="p-link--soft">
+          <a href="https://jaas.ai/redis" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/74f5267e-redis-icon.svg " alt="" class="p-logo">
           <p class="u-no-margin--top">Redis</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/ceph/" class="p-link--soft">
+          <a href="https://jaas.ai/ceph" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/f0331421-ceph-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">Ceph</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/wordpress/" class="p-link--soft">
+          <a href="https://jaas.ai/wordpress" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/60ca35aa-wordpress-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">Wordpress</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card u-no-margin--left" style="clear:both">
-        <a href="https://jujucharms.com/u/ibmcharmers/db2/" class="p-link--soft">
+          <a href="https://jaas.ai/u/ibmcharmers/db2" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/eb358275-db2-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">IBM DB2</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/u/hp-discover/nginx/" class="p-link--soft">
+          <a href="https://jaas.ai/u/hp-discover/nginx" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/a3b1dc20-nginx-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">nginx</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/nagios/" class="p-link--soft">
+          <a href="https://jaas.ai/nagios" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/07fbb544-nagios-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">nagios</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/mariadb/" class="p-link--soft">
+          <a href="https://jaas.ai/mariadb" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/0fe8aaaa-mariadb-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">MariaDB</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/postgresql/" class="p-link--soft">
+          <a href="https://jaas.ai/postgresql" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/de0e8fb8-postgresql-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">PostgresQL</p>
         </a>
       </li>
       <li class="col-2 u-align--center p-card">
-        <a href="https://jujucharms.com/mysql/" class="p-link--soft">
+          <a href="https://jaas.ai/mysql" class="p-link--soft">
           <img src="https://assets.ubuntu.com/v1/70ac97b0-mysql-icon.svg" alt="" class="p-logo">
           <p class="u-no-margin--top">MySQL</p>
         </a>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -36,7 +36,7 @@
           </div>
           <div class="col-4">
             <p>
-              <a class="p-button--positive is-wide" href="http://releases.ubuntu.com/18.04.3/ubuntu-18.04.3-desktop-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '18.04-cn', 'eventValue' : undefined });">直接下载</a>
+                <a class="p-button--positive is-wide" href="http://releases.ubuntu.com/18.04.4/ubuntu-18.04.4-desktop-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '18.04-cn', 'eventValue' : undefined });">直接下载</a>
             </p>
             <p><small>如需其他版本的Ubuntu，BT下载，网络安装器，本地镜像站，请参考<a href="https://www.ubuntu.com/download/alternative-downloads">其他下载</a>。</small></p>
           </div>
@@ -74,7 +74,7 @@
     </div>
     <div class="row">
       <div class="col-12 p-card--highlighted">
-        <h2>Ubuntu Server 18.04.3 LTS</h2>
+        <h2>Ubuntu Server 18.04.4 LTS</h2>
         <div class="p-card__content row">
           <div class="col-8">
             <p>Ubuntu服务器的长期支持版本将包含OpenStack，同样地安全更新也将支持至2023年4月，仅限64位平台。</p>
@@ -85,7 +85,7 @@
 
           <div class="col-4">
             <p>
-              <a href="http://releases.ubuntu.com/bionic/ubuntu-18.04.3-live-server-amd64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '18.04 Server-cn', 'eventValue' : undefined });">直接下载</a>
+              <a href="http://releases.ubuntu.com/bionic/ubuntu-18.04.4-live-server-amd64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '18.04 Server-cn', 'eventValue' : undefined });">直接下载</a>
             </p>
             <p><small>如需其他版本的Ubuntu，BT下载，网络安装器，本地镜像站，请参考<a href="https://www.ubuntu.com/download/alternative-downloads">此链接</a>。</small></p>
             <p>其他架构如ARM、Power、s390x可前往此链接<a href="http://cdimage.ubuntu.com/releases/18.04/release/">下载</a>。</p>
@@ -106,7 +106,7 @@
           </div>
           <div class="col-4">
             <p>
-              <a class="p-button--positive is-wide" href="http://releases.ubuntu.com/disco/ubuntu-19.10-live-server-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '19.10 Server-cn', 'eventValue' : undefined });">直接下载</a>
+                <a class="p-button--positive is-wide" href="http://releases.ubuntu.com/19.10/ubuntu-19.10-live-server-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '19.10 Server-cn', 'eventValue' : undefined });">直接下载</a>
             </p>
             <p>
               <small>如需其他版本的Ubuntu，BT下载，网络安装器，本地镜像站，请参考<a href="https://www.ubuntu.com/download/alternative-downloads">此链接</a>。</small>


### PR DESCRIPTION
Fixed a bunch of 404s including link to download ubuntu

Here are the missing ones: 

```
URL        `http://releases.ubuntu.com/ubuntu-core/16/'
Name       `下载树梅派镜像'
Parent URL http://127.0.0.1:5000/internet-of-things, line 206, col 34
Real URL   http://releases.ubuntu.com/ubuntu-core/16/
Check time 0.033 seconds
Size       281B
Result     Error: 404 Not Found

URL        `http://releases.ubuntu.com/ubuntu-core/16/ubuntu-core-16-dragonboard-410c.img.xz'
Name       `下载410c镜像'
Parent URL http://127.0.0.1:5000/internet-of-things, line 219, col 34
Real URL   http://releases.ubuntu.com/ubuntu-core/16/ubuntu-core-16-dragonboard-410c.img.xz
Check time 0.363 seconds
Size       281B
Result     Error: 404 Not Found
```