### PR TITLE
Linkchecker nigthly

### DIFF
--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -1,0 +1,31 @@
+name: Run linkchecker on site
+
+on:
+  schedule:
+    - cron:  '0 19 * * *'
+
+env:
+  PORT: 8010
+
+jobs:
+  run-linkchecker:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Build Docker image
+        run: DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag cn.ubuntu.com .
+
+      - name: Run server with Docker
+        run: docker run -p ${PORT}:80 cn.ubuntu.com &
+
+      - name: Check server status
+        run: curl localhost:${PORT}/_status/check -I
+
+      - name: Install linkchecker
+        run: sudo apt update && sudo apt install linkchecker
+
+      - name: Run linkchecker on live site
+        run: linkchecker --threads 2 --no-warnings --check-extern --ignore-url https://assets.ubuntu.com$ --ignore-url ".*(?:png|jpg|jpeg|gif|bmp|svg|js)$" --ignore-url /f_auto --ignore-url /q_auto --ignore-url /fl_sanitize --ignore-url /w_* --ignore-url /h_* --ignore-url https://www.gstatic.com$ --ignore-url https://res.cloudinary.com$ --ignore-url googleusercontent.com http://localhost:${PORT}

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -226,7 +226,7 @@
     <div class="col-8">
       <h3>使用conjure-up安装Kubernetes</h3>
       <p>Canonical的Kubernetes®发行版是Ubuntu团队与Google合作推出的一套纯粹的 Kubernetes，并已在众多云上采用现代标准和监控技术进行了测试。</p>
-      <p><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up">立即体验</a></p>
+      <p><a class="p-link--external" href="https://ubuntu.com/tutorials/install-kubernetes-with-conjure-up">立即体验</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Run the linkchecker nigthly to make sure we are not pointing to 404s from the site.

This job will do a `deep` search as it checks also every external links.

I think the next step would be to have a endpoint where we could send the report.