### PR TITLE
Bump blog to v5.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask_base==0.3.3
 canonicalwebteam.http==1.0.1
-canonicalwebteam.blog==4.0.2
+canonicalwebteam.blog==5.0.0
 canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.2.4
 gunicorn[gevent]


### PR DESCRIPTION
## Done

Bump blog to v5.0.0
This removes all the django bits.
Fixes #373 

## QA

- `./run`
- `/blog` Make sure that blog still works as usual.
