### PR TITLE
Corrects link to canonical.com

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -35,7 +35,7 @@
       <p>Ubuntu是一个古老的非洲语单词，意思是“Humanity to Others”（以人道善待他人），同时还有着“群在故我在”的意味。Ubuntu 操作系统将 Ubuntu 精神带到了计算机世界。 </p>
     </div>
     <div class="col-5">
-      <blockquote class="p-pull-quote"><p>Ubuntu也是<a href="https://wwww.canonical.com" class="p-link--external">Canonical</a>公司的产品和所有的品牌商标，而科能（上海）软件科技有限公司则是Canonical公司在中国注册的子公司，公司总部位于英国伦敦。</p></blockquote>
+      <blockquote class="p-pull-quote"><p>Ubuntu也是<a href="https://canonical.com" class="p-link--external">Canonical</a>公司的产品和所有的品牌商标，而科能（上海）软件科技有限公司则是Canonical公司在中国注册的子公司，公司总部位于英国伦敦。</p></blockquote>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Corrected link to canonical.com

## QA

1. Launch the site
1. Go to /about
1. Find the link to “Canonical” and follow it
1. Observe that you’re now on canonical.com

## Issue / Card

#377