### PR TITLE
Remove reference to discontinued Mythbuntu from /about

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -83,7 +83,6 @@
         <li class="p-list__item is-ticked"><a href="http://www.kubuntu.org/">Kubuntu</a> — 具有 K Desktop 环境的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="http://www.ubuntukylin.com/">Ubuntu Kylin</a> — 针对中国用户进行本地化设计的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="https://wiki.ubuntu.com/Lubuntu?_ga=1.214374615.1590733534.1425993218">Lubuntu</a> — 采用 LXDE 的 Ubuntu</li>
-        <li class="p-list__item is-ticked"><a href="http://www.mythbuntu.org/">Mythbuntu</a> — 为使用 MythTV 打造家庭影院电脑而设计的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="http://ubuntustudio.org/">Ubuntu Studio</a> — 为多媒体剪辑和制作而设计的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="http://xubuntu.org/">Xubuntu</a> — 具有 XFCE 桌面环境的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="https://ubuntu-mate.org/">Ubuntu MATE</a> — 具有 MATE 桌面环境的 Ubuntu</li>


### PR DESCRIPTION
## Done

Removed a list item that referred to the old Mythbuntu flavor from the /about page.

## QA

Confirm Mythbuntu is no longer mentioned anywhere

## Issue / Card

N/A