### PR TITLE
Update release info

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -18,10 +18,10 @@ previous_lts:
 
 checksums:
   desktop:
-    "20.04": "still need the desktop checksum"
+    "20.04": "e5b72e9cfe20988991c9cd87bde43c0b691e3b67b01f76d23f8150615883ce11 *ubuntu-20.04-desktop-amd64.iso"
     "19.10": 96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso
     "18.04.4": c0d025e560d54434a925b3707f8686a7f588c42a5fbc609b8ea2447f88847041 *ubuntu-18.04.4-desktop-amd64.iso
   live-server:
-    "20.04": "still need the live server checksum"
+    "20.04": "caf3fd69c77c439f162e2ba6040e9c320c4ff0d69aad1340a514319a9264df9f *ubuntu-20.04-live-server-amd64.iso"
     "19.10": 3fe242f4b330ead8191b3c200bcf1d8d3be4243d62fe6b866a778499370c9dbb *ubuntu-19.10-live-server-amd64.iso
     "18.04.4": 73b8d860e421000a6e35fdefbb0ec859b9385b0974cf8089f5d70a87de72f6b9 *ubuntu-18.04.4-live-server-amd64.iso

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -90,7 +90,7 @@
 
           <div class="col-4">
             <p>
-              <a href="http://releases.ubuntu.com/bionic/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ releases.lts.short_version }} Server-cn', 'eventValue' : undefined });">直接下载</a>
+              <a href="http://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ releases.lts.short_version }} Server-cn', 'eventValue' : undefined });">直接下载</a>
             </p>
             <p><small>如需其他版本的Ubuntu，BT下载，网络安装器，本地镜像站，请参考<a href="https://www.ubuntu.com/download/alternative-downloads">此链接</a>。</small></p>
             <p>其他架构如ARM、Power、s390x可前往此链接<a href="http://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/">下载</a>。</p>


### PR DESCRIPTION
## Done

- Fixed bad server link
- Updated releases.yaml (however not used for checksums currently)

## QA

- https://0.0.0.0:8010/download and see that the download buttons work

