### PR TITLE
/about: Update Lubuntu, remove Ubuntu GNOME

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -73,10 +73,9 @@
       <p>下面是以 Ubuntu 为基础并为 Ubuntu 项目做出巨大贡献的分支版本。</p>
       <ul class="p-list--divided">
         <li class="p-list__item is-ticked"><a href="http://www.edubuntu.org/">Edubuntu</a> — 面向教育领域的 Ubuntu</li>
-        <li class="p-list__item is-ticked"><a href="http://ubuntugnome.org/">Ubuntu GNOME</a> — 具有 GNOME 桌面环境的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="http://www.kubuntu.org/">Kubuntu</a> — 具有 K Desktop 环境的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="http://www.ubuntukylin.com/">Ubuntu Kylin</a> — 针对中国用户进行本地化设计的 Ubuntu</li>
-        <li class="p-list__item is-ticked"><a href="https://wiki.ubuntu.com/Lubuntu?_ga=1.214374615.1590733534.1425993218">Lubuntu</a> — 采用 LXDE 的 Ubuntu</li>
+        <li class="p-list__item is-ticked"><a href="https://lubuntu.me/">Lubuntu</a> — 采用 LXQt 的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="http://ubuntustudio.org/">Ubuntu Studio</a> — 为多媒体剪辑和制作而设计的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="http://xubuntu.org/">Xubuntu</a> — 具有 XFCE 桌面环境的 Ubuntu</li>
         <li class="p-list__item is-ticked"><a href="https://ubuntu-mate.org/">Ubuntu MATE</a> — 具有 MATE 桌面环境的 Ubuntu</li>


### PR DESCRIPTION
## Done

* Updated the Lubuntu link to a non-deprecated site, and swapped the reference to LXDE to LXQt. Removed the creepy Google Analytics tracker.
* Removed the Ubuntu GNOME link. That flavor died when Canonical stopped developing the Unity DE and changed the default Ubuntu environment to Gnome Shell, years ago.

## QA

Check rendering of the /about page.

## Issue / Card

N/A