### PR TITLE
New OpenStack campaign & contact page update

### DIFF
--- a/templates/contact/index.html
+++ b/templates/contact/index.html
@@ -20,14 +20,14 @@
             <h4>网站支持</h4>
               <p>如您对Ubuntu中文官网有任何意见或需修正的地方，可到Github<a href="https://github.com/canonical-websites/cn.ubuntu.com/issues/new">提交bug</a>。</p>
             <h4>售前支持</h4>
-              <p>如您需要Ubuntu官方支持服务可发邮件到此<a href="mailto:liam.zheng@canonical.com">邮箱</a>。此邮箱不提供Ubuntu系统使用技术支持。</p>
+              <p>如您需要Ubuntu官方支持服务可发邮件到此<a href="mailto:liam.zheng@canonical.com" class="p-link--external">邮箱</a>，或填写右侧的表格。</p>
       </div>
 
       <div class="col-7">
         <div class="row">
           <div class="col-6 col-start-large-3">
-            <h4>Ubuntu服务产品支持</h4>
-            <p>在向您提供支持前，请填写以下表格。我们将在一个工作日内与您取得联系。<br />注：仅支持工作邮箱的咨询。</p>
+            <h2>Ubuntu产品服务支持</h2>
+            <p>在向您提供支持前，请填写以下表格。我们将在一个工作日内与您取得联系。（注：请您填写工作邮箱）</p>
 
   <!-- MARKETO FORM -->
   <script src="https://assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
@@ -160,10 +160,8 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3>北京办公室</h3>
-      <p>电话：+86 (10) 5737 9099</p>
       <p>地址：北京市朝阳区建国门外大街1号国贸写字楼1座11层1118-19室</p>
       <p>邮编: 100004</p>
-      <p>*注意：此号码不提供系统使用支持</p>
     </div>
     <div class="col-6 p-card">
       <h3>上海办公室</h3>

--- a/templates/engage/openstack-ussuri-webinar.html
+++ b/templates/engage/openstack-ussuri-webinar.html
@@ -1,0 +1,141 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Openstack Ussuri 研讨会{% endblock %}
+{% block meta_description %}Openstack Ussuri研讨会{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1bqD9QKDj6ZfRkn-vbDrHHE_Zrk81cA5hFLRHZYFzzSA{% endblock meta_copydoc %}
+
+{% block content %}
+
+
+<section class="p-strip p-strip--suru-bottomed">
+    <div class="row u-equal-height">
+      <div class="col-7  u-vertically-center">
+        <div>
+          <h1>Openstack Ussuri线上研讨会：新功能介绍</h1>
+          <h4>最新版OpenStack Ussuri现已可在Ubuntu 20.04 LTS和Ubuntu 18.04 LTS上的使用</h4>
+        </div>
+      </div>
+        <div class="col-5 u-hide--small u-align--center u-vertically-center">
+          <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_250,h_160/https://assets.ubuntu.com/v1/669390e0-openstack-cloud.svg" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_500,h_320/https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg 2x" alt="" width="250" height="160" loading="auto" style="max-height: 410px; max-width: 250px;">
+        </div>
+    </div>
+</section>
+
+<section class="p-strip is-shallow is-bordered">
+    <div class="row">
+      <div class="col-7">
+        <p>最新版的OpenStack Ussuri继续提供可靠和安全的基础架构层，同时也在不断发展以满足各种用例。 最显着的改进包括围绕开放虚拟网络（OVN）的稳定工作以及对Masakari项目的更新，这些更新使组织可以在开源软件定义网络（SDN）平台的顶部运行高可用性工作负载。</p>
+        <p>“<a href="/download/" </a>Ubuntu 20.04 LTS</a>上的OpenStack Ussuri将会拥有5年的企业支持和10年的开箱即用的安全更新，在引入例如OVN和Masakari等主要改进的同时使得其成为OpenStack在生产环境部署的理想选择。” </p>
+        <p>版本新特性一览：</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">OVN和Masakari charms的一次稳定版本</li>
+          <li class="p-list__item is-ticked">新的后端数据库–MySQL InnoDB Cluster 8.0</li>
+          <li class="p-list__item is-ticked">通过iSSI网关支持单机Ceph集群</li>
+          <li class="p-list__item is-ticked">其他新特性见研讨会内容</li>
+        </ul>
+      </div>
+
+      <div class="col-5">
+ <!-- MARKETO FORM -->
+ <script src="https://assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
+ <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+ <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
+ <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3620" style="margin-top: -1rem;" novalidate="novalidate">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <ul class="p-list">
+      <li class="mktFormReq mktField p-list__item">
+        <label for="FirstName" class="mktoLabel">名字：</label>
+        <input required="" id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="First Name" aria-required="true">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="LastName" class="mktoLabel ">姓氏：</label>
+        <input required="" id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Last Name" aria-required="true">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Email" class="mktoLabel ">工作邮箱：</label>
+        <input required="" id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" aria-label="Email" aria-required="true">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Company" class="mktoLabel ">公司名称：</label>
+        <input required="" id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name" aria-required="true">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Title" class="mktoLabel ">职位：</label>
+        <input required="" id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title" aria-required="true">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Phone" class="mktoLabel ">电话号码：</label>
+        <input required="" id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel" aria-label="Phone Number" aria-required="true">
+      </li>
+      <li class="mktField">
+        <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel "><small>我同意接收有关Canonical的产品和服务信息。</small></label>
+       </li>
+       <li class="mktField">
+        <p><small>在提交此表格的同时，我确认已阅读和同意<a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy/contact">的隐私声明</a>和<a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy">隐私政策</small></a>。
+          <input name="RichText" aria-label="RichText" type="hidden">
+        </p>
+       </li>
+      <li class="mktField">
+        <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="None" type="hidden">
+      </li>
+      <li class="mktField">
+        <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="None" type="hidden">
+      </li>
+      <li class="mktField">
+        <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="None" type="hidden">
+      </li>
+      <li class="mktField">
+        <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+      </li>
+      <li class="mktField">
+        <br />
+      </li>
+      <li class="mktField">
+        <button type="submit" class="mktoButton u-no-margin--bottom">现在注册</button>
+        <input name="formid" aria-label="formid" class="mktoField" value="3620" type="hidden">
+        <input name="lpId" aria-label="lpId" class="mktoField " value="" type="hidden">
+        <input name="subId" aria-label="subId" class="mktoField " value="" type="hidden">
+        <input name="munchkinId" aria-label="munchkinId" class="mktoField " value="" type="hidden">
+        <input name="lpurl" aria-label="lpurl" class="mktoField " value="" type="hidden">
+        <input name="cr" aria-label="cr" class="mktoField " value="" type="hidden">
+        <input name="kw" aria-label="kw" class="mktoField " value="" type="hidden">
+        <input name="q" aria-label="q" class="mktoField " value="" type="hidden">
+      </li>
+    </ul>
+  </fieldset>
+  <input type="hidden" name="returnURL" aria-label="returnURL" value="https://live.polyv.cn/watch/1402766">
+  <input type="hidden" name="retURL" aria-label="retURL" value="https://live.polyv.cn/watch/1402766">
+ </form>
+ <script>
+  $("#mktoForm_3620").validate({
+    errorElement: "span",
+    errorClass: "mktFormMsg mktError",
+    onkeyup: false,
+    onclick: false,
+    onblur: false
+  });
+  $(function () {
+    $("#comments").hide()
+  });
+  $('#Ubuntu_User__c').on('change', function () {
+    var selection = $(this).val();
+    if (selection == 'Commercially only') {
+      $('#comments').show();
+    } else {
+      $('#comments').hide();
+    }
+  });
+ </script>
+ <script src="https://assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
+
+ <!-- /MARKETO FORM -->
+
+      </div>
+
+    </div>
+</section>
+
+
+{% endblock content %}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,9 +10,9 @@
 
 <!-- Section 1: Hero -->
 <template id="takeovers" class="u-hide">
-  {% include "takeovers/_2004-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_desktop-developer-takeover.html" %}
+  {% include "takeovers/_openstack-ussuri.html" %}
 </template>
 
 <section class="p-strip is-deep is-bordered">

--- a/templates/takeovers/_openstack-ussuri.html
+++ b/templates/takeovers/_openstack-ussuri.html
@@ -1,0 +1,16 @@
+{% with title="OpenStack Ussuri 新版发布线上研讨会",
+subtitle="与我们的技术专家一起了解新版本。",
+class="p-strip--suru-bottomed",
+header_image="https://assets.ubuntu.com/v1/669390e0-openstack-cloud.svg",
+image_style="",
+image_height="290",
+image_width="380",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/engage/openstack-ussuri-webinar.html",
+primary_cta="前往注册",
+primary_cta_class="",
+lang="",
+locale="" %}
+{% include "takeovers/shared/_template.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done

- Create takeover and engage page for OpenStack Ussuri webinar

- Update index page, remove 20.04 takeover from cycle list 

- Update contact page, remove phone number 




