### PR TITLE
Update blog module version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 canonicalwebteam.flask_base==0.6.3
 canonicalwebteam.http==1.0.3
-canonicalwebteam.blog==6.0.0
+canonicalwebteam.blog==6.2.1
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.image-template==1.1.0
+canonicalwebteam.image-template==1.2.0
 pyyaml==5.3.1
 gunicorn[gevent]

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -15,18 +15,7 @@
     {% if article.image and article.image.source_url %}
     <div class="u-crop--16-9">
       <a href="/blog/{{ article.slug }}">
-        <img
-          src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}"
-          srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }} 460w,
-                                                                                         https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{ article.image.source_url }} 620w,
-                                                                                                       https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{ article.image.source_url }} 875w"
-          sizes="(min-width: 1031px) 460px,
-                                                                                                     (max-width: 1030px) and (min-width: 876px) 460px,
-                                                                                                                   (max-width: 875px) and (min-width: 621px) 875px,
-                                                                                                                                 (max-width: 620px) and (min-width: 461px) 620px,
-                                                                                                                                               (max-width: 460px) 460px"
-          alt=""
-        />
+        {{ article.image.rendered|safe }}
       </a>
     </div>
     {% endif %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,7 +1,7 @@
 import yaml
 import talisker
 
-from canonicalwebteam.blog import build_blueprint, BlogViews, Wordpress
+from canonicalwebteam.blog import build_blueprint, BlogViews, BlogAPI
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
 from canonicalwebteam import image_template
@@ -21,10 +21,7 @@ app.add_url_rule("/", view_func=template_finder_view)
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 blog_views = BlogViews(
-    api=Wordpress(session=session),
-    tag_ids=[3265],
-    blog_title="博客",
-    per_page=11,
+    api=BlogAPI(session=session), tag_ids=[3265], blog_title="博客", per_page=11,
 )
 app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 


### PR DESCRIPTION
This will do two things:
1) Rewrite the admin.insights.ubuntu.com/wp-content to ubuntu.com/wp-content
2) Enable cloudinary for both thumbnails and article images

## QA

Click on the demo link. Browse to `/blog`.

Check that thumbnails are ok. Click on some articles, check the images are fine:
The urls of the images should be pointing to `ubuntu.com/wp-content` not `admin.insights.ubuntu.com/wp-content`
The cloudinary service should be enabled for both thumbnails and article images.