### PR TITLE
Add cookie-policy v3.0.3

### DIFF
--- a/.webpack/entry.js
+++ b/.webpack/entry.js
@@ -1,5 +1,6 @@
 module.exports = {
   ['global-nav']: './static/js/src/global-nav.js',
+  ['cookie-policy']: './static/js/src/cookie-policy.js',
   ['latest-news']: './static/js/src/latest-news.js',
   ['forms']: [
     './static/js/third-party/serialize.js',

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@canonical/global-nav": "2.4.3",
+    "@canonical/cookie-policy": "3.0.3",
     "vanilla-framework": "2.19.1"
   }
 }

--- a/static/js/src/cookie-policy.js
+++ b/static/js/src/cookie-policy.js
@@ -1,0 +1,3 @@
+import { cookiePolicy } from '@canonical/cookie-policy';
+
+cookiePolicy();

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -3,21 +3,24 @@
 @import 'settings';
 
 // Import Vanilla Framework
-@import "vanilla-framework/scss/build";
+@import 'vanilla-framework/scss/build';
 @import 'patterns_navigation';
 
 @include cn-p-navigation;
 
 // Import custom styles
-@import "custom/ubuntu_intro";
-@import "custom/heading-icon-small";
+@import 'custom/ubuntu_intro';
+@import 'custom/heading-icon-small';
 @import 'pattern_blog-post';
 @import 'pattern_blog-card';
 @import 'pattern_blog-list';
-@import "pattern_chart";
-@import "pattern_strip";
-@import "pattern_takeovers";
+@import 'pattern_chart';
+@import 'pattern_strip';
+@import 'pattern_takeovers';
 @import 'utility_crop';
+
+// import cookie policy
+@import '@canonical/cookie-policy/build/css/cookie-policy';
 
 @include blog-p-list;
 @include blog-p-post;

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -67,7 +67,8 @@
   <!-- footer content goes here -->
   {% include "templates/footer.html" %}
 
-<script src="/static/js/dist/global-nav.min.js" defer></script>
+<script src="{{ versioned_static('js/dist/global-nav.min.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/cookie-policy.min.js') }}" defer></script>
 
 
 </body>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -16,10 +16,10 @@
             <a class="p-link--soft p-link--external" href="https://www.ubuntu.com/legal">Legal information</a>
           </li>
           <li class="p-inline-list__item">
-            <a class="p-link--soft p-link--external" href="https://github.com/canonical-websites/cn.ubuntu.com/issues/new">Report a bug with this site</a>
+            <a class="p-link--soft js-revoke-cookie-manager" href="">Manage your tracker settings</a>
           </li>
           <li class="p-inline-list__item">
-            <a class="p-link--soft js-revoke-cookie-manager" href="">Manage your tracker settings</a>
+            <a class="p-link--soft p-link--external" href="https://github.com/canonical-websites/cn.ubuntu.com/issues/new">Report a bug with this site</a>
           </li>
         </ul>
         <span class="u-off-screen">

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -18,6 +18,9 @@
           <li class="p-inline-list__item">
             <a class="p-link--soft p-link--external" href="https://github.com/canonical-websites/cn.ubuntu.com/issues/new">Report a bug with this site</a>
           </li>
+          <li class="p-inline-list__item">
+            <a class="p-link--soft js-revoke-cookie-manager" href="">Manage your tracker settings</a>
+          </li>
         </ul>
         <span class="u-off-screen">
           <a href="#">Go to the top of the page</a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1409,6 +1409,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@canonical/cookie-policy@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.3.tgz#77ff09de8cc91c3bd12d23bfeaaf23a0206995ad"
+  integrity sha512-cTNrBAO+w5Akrn32Arkp/YGgT9KXTUuCMAgE8ipABBtkEIQ2Z708mTkZ3FNgefxPvMuDuLCVvKhvHik31SEShg==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done
Add cookie-policy v3.0.3

**Do not merge until @pmahnke has done the GTM changes**

## QA
- Load the demo and you should see the cookie policy
- Open the manager and select something
- See it is gone
- Click the link in the footer to manage cookies
- See it opens again without errors in the console.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/cn.ubuntu.com/issues/440