### PR TITLE
Update the releases.yaml for 20.10 release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,27 +1,29 @@
 latest:
-  slug: EoanErmine
-  short_version: "19.10"
-  full_version: "19.10"
-  release_date: "October 2019"
-  eol: 2020
+  slug: GroovyGorilla
+  short_version: '20.10'
+  full_version: '20.10'
+  release_date: 'October 2020'
+  eol: 2021
 lts:
   slug: FocalFossa
-  short_version: "20.04"
-  full_version: "20.04.1"
-  release_date: "April 2020"
+  short_version: '20.04'
+  full_version: '20.04.1'
+  release_date: 'April 2020'
   eol: 2025
 openstack_lts:
   slug: Ussuri
 previous_lts:
-  short_version: "18.04"
-  full_version: "18.04.5"
+  short_version: '18.04'
+  full_version: '18.04.5'
 
 checksums:
   desktop:
-    "20.04.1": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.04.1-desktop-amd64.iso"
-    "19.10": "96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso"
-    "18.04.5": "f295570badb09a606d97ddfc3421d7bf210b4a81c07ba81e9c040eda6ddea6a0 *ubuntu-18.04.5-desktop-amd64.iso"
+    '20.10': 'b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.10-desktop-amd64.iso'
+    '20.04.1': 'b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.04.1-desktop-amd64.iso'
+    '19.10': '96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso'
+    '18.04.5': 'f295570badb09a606d97ddfc3421d7bf210b4a81c07ba81e9c040eda6ddea6a0 *ubuntu-18.04.5-desktop-amd64.iso'
   live-server:
-    "20.04.1": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.04.1-live-server-amd64.iso"
-    "19.10": "3fe242f4b330ead8191b3c200bcf1d8d3be4243d62fe6b866a778499370c9dbb *ubuntu-19.10-live-server-amd64.iso"
-    "18.04.5": "3756b3201007a88da35ee0957fbe6666c495fb3d8ef2e851ed2bd1115dc36446 *ubuntu-18.04.5-live-server-amd64.iso"
+    '20.10': '443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.10-live-server-amd64.iso'
+    '20.04.1': '443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.04.1-live-server-amd64.iso'
+    '19.10': '3fe242f4b330ead8191b3c200bcf1d8d3be4243d62fe6b866a778499370c9dbb *ubuntu-19.10-live-server-amd64.iso'
+    '18.04.5': '3756b3201007a88da35ee0957fbe6666c495fb3d8ef2e851ed2bd1115dc36446 *ubuntu-18.04.5-live-server-amd64.iso'

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -47,14 +47,14 @@
         </div>
       </div>
     </div>
-  
+
     {% if releases.latest.short_version > releases.lts.short_version %}
     <div class="p-strip is-shallow">
       <div class="u-fixed-width">
         <hr>
       </div>
     </div>
-  
+
     <div class="u-fixed-width">
       <h2>Ubuntu {{ releases.latest.full_version }}</h2>
       <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
@@ -68,14 +68,14 @@
             <a class="p-button--positive is-wide js-latest-download" href="http://releases.ubuntu.com/{{ releases.latest.full_version }}/ubuntu-{{ releases.latest.full_version }}-desktop-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">下载</a>
           </p>
           <p>
-            <small><a href="https://ubuntu.com/download/alternative-downloads" class="p-link--external">其他下载和BT&nbsp;&rsaquo;</a></small>
+            <small><a href="https://ubuntu.com/download/alternative-downloads" class="p-link--external">其他下载和BT</a></small>
           </p>
         </div>
       </div>
     </div>
     {% endif %}
   </section>
- 
+
 
   <div class="p-strip is-bordered">
     <div class="row">

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -112,7 +112,7 @@
         <h2>Ubuntu Server {{ releases.latest.full_version }}</h2>
         <div class="p-card__content row">
           <div class="col-8">
-            <p>最新版本Ubuntu Server，拥有9个月安全维护更新，支持到2020年7月。</p>
+            <p>最新版本Ubuntu Server，Ubuntu {{ releases.latest.full_version }} 拥有9个月安全维护更新，支持到{{ releases.latest.eol }}年6月。</p>
             <p>
               <a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.latest.short_version }} LTS 发布公告</a>
             </p>


### PR DESCRIPTION
## Done
Update the releases.yaml for 20.10 release

## QA
- Open the demo
- Go to /download
- See that there is a 20.10 download option

## Issue / Card
Fixes https://github.com/canonical-web-and-design/cn.ubuntu.com/issues/450

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/96712412-059b8600-1397-11eb-95da-8a6a8812d2d4.png)

