### PR TITLE
Fix border bleed on fieldsets

### DIFF
--- a/templates/engage/2004-launch.html
+++ b/templates/engage/2004-launch.html
@@ -53,7 +53,7 @@
   <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
   <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
   <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3563" style="margin-top: -1rem;" novalidate="novalidate">
-   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
      <ul class="p-list">
        <li class="mktFormReq mktField p-list__item">
          <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/developer-desktop.html
+++ b/templates/engage/developer-desktop.html
@@ -64,7 +64,7 @@
 <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
 <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
 <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3488" style="margin-top: -1rem;" novalidate="novalidate">
- <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+ <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
    <ul class="p-list">
      <li class="mktFormReq mktField p-list__item">
        <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/microsoft-active-directory.html
+++ b/templates/engage/microsoft-active-directory.html
@@ -68,7 +68,7 @@
 <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
 <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
 <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3446" style="margin-top: -1rem;" novalidate="novalidate">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/openstack-ussuri-webinar.html
+++ b/templates/engage/openstack-ussuri-webinar.html
@@ -42,7 +42,7 @@
  <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
  <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
  <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3620" style="margin-top: -1rem;" novalidate="novalidate">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/redhat-openstack-comparison-whitepaper.html
+++ b/templates/engage/redhat-openstack-comparison-whitepaper.html
@@ -43,7 +43,7 @@
  <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
  <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
  <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3749" style="margin-top: -1rem;" novalidate="novalidate">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/robot-operating-system-choice-cn.html
+++ b/templates/engage/robot-operating-system-choice-cn.html
@@ -121,7 +121,7 @@
 <script src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
 <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
 <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3346" style="margin-top: -1rem;" novalidate="novalidate">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/shared/_base_engage_markdown.html
+++ b/templates/engage/shared/_base_engage_markdown.html
@@ -111,7 +111,7 @@
         <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
         <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
         <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3446" style="margin-top: -1rem;" novalidate="novalidate">
-         <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+         <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
            <ul class="p-list">
              <li class="mktFormReq mktField p-list__item">
                <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/ubuntu-tech-live-episode-1.html
+++ b/templates/engage/ubuntu-tech-live-episode-1.html
@@ -44,7 +44,7 @@
   <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
   <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
   <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3674" style="margin-top: -1rem;" novalidate="novalidate">
-   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
      <ul class="p-list">
        <li class="mktFormReq mktField p-list__item">
          <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/ubuntu-tech-live-episode-2.html
+++ b/templates/engage/ubuntu-tech-live-episode-2.html
@@ -42,7 +42,7 @@
   <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
   <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
   <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3704" style="margin-top: -1rem;" novalidate="novalidate">
-   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
      <ul class="p-list">
        <li class="mktFormReq mktField p-list__item">
          <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/ubuntu-tech-live-episode-3.html
+++ b/templates/engage/ubuntu-tech-live-episode-3.html
@@ -43,7 +43,7 @@
   <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
   <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
   <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3739" style="margin-top: -1rem;" novalidate="novalidate">
-   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
      <ul class="p-list">
        <li class="mktFormReq mktField p-list__item">
          <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/ubuntu-tech-live-episode-4.html
+++ b/templates/engage/ubuntu-tech-live-episode-4.html
@@ -12,16 +12,16 @@
         <h1>Ubuntu Tech Live第四期：Ubuntu Core的网络安全分析</h1>
           <p class="p-heading--four">我们邀请了独立第三方测评机构Rule4一起来讨论和分析Ubuntu Core的安全性</p>
       </div>
-      <div class="u-vertically-center col-5 col-start-large-8 u-align--center u-hide--small">      
+      <div class="u-vertically-center col-5 col-start-large-8 u-align--center u-hide--small">
           <img src="https://assets.ubuntu.com/v1/53cbe6de-rule4logo-rev.png" style="width: 400px;" alt="security">
       </div>
     </div>
   </div>
 </section>
-  
+
   <section class="p-strip--light is-shallow">
     <div class="row">
-      <div class="col-7">          
+      <div class="col-7">
           <h2>内容介绍: </h2>
           <p>我们提供了大量文档和内容来支持Ubuntu Core架构。但是我们不希望任何人在选择Ubuntu时是因为我们一家之言。因此，我们引入<a class="p-link--external" href="https://www.rule4.com">Rule4</a>来对Ubuntu Core的安全体系结构控制进行独立的第三方评估。</p>
           <p>在本次研讨会中，我们将讨论测试过程和发现，深入研究强化，复杂性管理，DevOps和SOAR校准，高速部署，生命周期管理，沙盒化等等。同时，我们也将讨论优势分析和运营安全性考虑因素，并找出为什么Rule4得出的如下结论：</p>
@@ -33,17 +33,17 @@
           </div>
           <br>
           <small style="font-style:italic"><strong>Ubuntu Tech Live</strong>是全新一档由Ubuntu / Canonical官方开设，并专为开发者和企业所设计的栏目。活动以视频直播的方式向大家介绍Ubuntu最新的技术和产品。
-            设置有问答环节，Canonical专家现场为您解答相关问题。同时，也将不定期邀请合作伙伴、业内专家分享相关有趣的主题。</small>        
+            设置有问答环节，Canonical专家现场为您解答相关问题。同时，也将不定期邀请合作伙伴、业内专家分享相关有趣的主题。</small>
       </div>
 
       <div class="col-5">
-  
+
         <!-- MARKETO FORM -->
   <script src="https://assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
   <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
   <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
   <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3773" style="margin-top: -1rem;" novalidate="novalidate">
-   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
      <ul class="p-list">
        <li class="mktFormReq mktField p-list__item">
          <label for="FirstName" class="mktoLabel">名字：</label>
@@ -72,7 +72,7 @@
        <li class="mktField">
         <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel "><small>我同意接收有关Canonical的产品和服务信息。</small></label>
        </li>
-       <li class="mktField">           
+       <li class="mktField">
         <p><small>在提交此表格的同时，我确认已阅读和同意<a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy/contact">的隐私声明</a>和<a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy">隐私政策</small></a>。
           <input name="RichText" aria-label="RichText" type="hidden">
         </p>
@@ -129,7 +129,7 @@
    });
   </script>
   <script src="https://assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
-  
+
   <!-- /MARKETO FORM -->
     </div>
   </section>

--- a/templates/engage/uc18wb.html
+++ b/templates/engage/uc18wb.html
@@ -58,7 +58,7 @@
   <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
   <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
   <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3452" style="margin-top: -1rem;" novalidate="novalidate">
-    <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
       <ul class="p-list">
         <li class="mktFormReq mktField p-list__item">
           <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/vmware-to-openstack.html
+++ b/templates/engage/vmware-to-openstack.html
@@ -67,7 +67,7 @@
  <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
  <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
  <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3548" style="margin-top: -1rem;" novalidate="novalidate">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="FirstName" class="mktoLabel">名字：</label>

--- a/templates/engage/xdf-maas-ebook.html
+++ b/templates/engage/xdf-maas-ebook.html
@@ -50,7 +50,7 @@
  <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
  <script src="https://assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>&zwnj;&#8203;
  <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3645" style="margin-top: -1rem;" novalidate="novalidate">
-  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px; border-color:#cdcdcd;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="FirstName" class="mktoLabel">名字：</label>


### PR DESCRIPTION
## Done

- fix border bleed [issue](https://github.com/canonical-web-and-design/vanilla-framework/issues/3424) by adding `border-color:#cdcdcd;` to the fieldsets

## QA

1. Download this branch and run it.
2. compare http://0.0.0.0:8010/engage/ubuntu-tech-live-episode-3 with https://cn.ubuntu.com/engage/ubuntu-tech-live-episode-3


## Screenshots

[live]
![image](https://user-images.githubusercontent.com/441217/100108935-3f165400-2e63-11eb-8a50-ebeb0e5adfc1.png)

[this branch]
![image](https://user-images.githubusercontent.com/441217/100108999-4ccbd980-2e63-11eb-8405-badbaff134e6.png)

