### PR TITLE
Fix /internet-of-things submenu

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -31,7 +31,7 @@
     <div class="row u-vertically-center">
       <div class="col-6">
         <h1>专为物联网<br>倾力打造的Ubuntu</br></h1>
-          <p>从智能家居到智能无人机，机器人，工业系统，Ubuntu是<a class="p-link--inverted" href="https://ubuntu.com/embedded" style="font-style: italic;">嵌入式Linux的新标准</a>。全球最好的安全性，定制品牌应用商店，庞大的开发者社区和可靠的安全更新。</a>
+          <p>从智能家居到智能无人机，机器人，工业系统，Ubuntu是<a class="p-link--inverted" href="https://ubuntu.com/embedded" style="font-style: italic;">嵌入式Linux的新标准</a>。全球最好的安全性，定制品牌应用商店，庞大的开发者社区和可靠的安全更新。
         </p>
       </div>
 

--- a/templates/internet-of-things/secondary-nav.html
+++ b/templates/internet-of-things/secondary-nav.html
@@ -14,7 +14,7 @@
           <a class="breadcrumbs__link {% if request.path == '/internet-of-things/core' %}p-link--active{% else %}p-link--soft{% endif %}" href="/internet-of-things/core">什么是UbuntuCore</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link" href="https://ubuntu.com/core/docs">Ubuntu Core文档</a>
+          <a class="breadcrumbs__link p-link--external p-link--soft" href="https://ubuntu.com/core/docs">Ubuntu Core文档</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

- Fix /internet-of-things submenu
- Removed extra `</a>`

## QA

- go to http://0.0.0.0:8005/internet-of-things and see that the subnav looks correct.

