### PR TITLE
Fix secondary nav after Vanilla 2.30 update

### DIFF
--- a/static/sass/_patterns_navigation.scss
+++ b/static/sass/_patterns_navigation.scss
@@ -39,6 +39,10 @@
       position: relative;
       width: 7.07rem;
     }
+    // Fix secondary navigation (moved to the right after Vanilla 2.30)
+    .row {
+      padding-left: 1rem;
+    }
   }
 
   .breadcrumbs {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -64,23 +64,6 @@ body {
   padding: 0.6875rem 1rem !important;
 }
 
-// XXX Fix for inline image SVGs that have no dimensions set
-// https://github.com/vanilla-framework/vanilla-framework/issues/1605
-.p-inline-images__item > img {
-  max-height: 5rem;
-  max-width: 9rem;
-}
-
-// XXX Fix for missing borders, remove with Vanilla 2.X
-[class^='p-strip'].is-bordered {
-  margin-bottom: initial;
-}
-
-/// XXX Missing, should be in Vanilla
-.u-align--center {
-  max-width: none;
-}
-
 // XXX Fix the max-width
 .u-no-max-width {
   max-width: none;

--- a/templates/support/esm.html
+++ b/templates/support/esm.html
@@ -43,8 +43,8 @@
     </div>
   </div>
   
-  <section class="p-strip--suru-accent is-dark">
-    <div class="row p-divider">
+  <section class="p-strip--suru">
+    <div class="row p-divider is-dark">
       <div class="col-6 p-divider__block">
         <div class="p-heading-icon--small">
           <div class="p-heading-icon__header">


### PR DESCRIPTION
## Done

- Fix secondary navigation
- Remove old styles fixed by Vanilla 2.30
- Fix background color on ESM support page

## QA

- Compare currente site navigation (when in the IoT page) https://cn.ubuntu.com/internet-of-things
with https://cn-ubuntu-com-537.demos.haus/internet-of-things
- Fixed background color on https://cn-ubuntu-com-537.demos.haus/support/esm

## Issue / Card

Fixes #536

## Screenshots

<img width="1440" alt="Screenshot 2021-06-10 at 17 24 33" src="https://user-images.githubusercontent.com/14939793/121561810-be8aff80-ca10-11eb-9813-1a44cded482f.png">
