### PR TITLE
Bump the point release to 20.04.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,46 +1,45 @@
 latest:
   slug: HirsuteHippo
-  name: "Hirsute Hippo"
-  short_version: "21.04"
-  full_version: "21.04"
-  release_date: "April 2021"
-  eol: "2022年1月"
+  name: 'Hirsute Hippo'
+  short_version: '21.04'
+  full_version: '21.04'
+  release_date: 'April 2021'
+  eol: '2022年1月'
   past_eol_date: false
-  release_notes_url: "https://discourse.ubuntu.com/t/hirsute-hippo-release-notes/19221"
+  release_notes_url: 'https://discourse.ubuntu.com/t/hirsute-hippo-release-notes/19221'
 lts:
   slug: FocalFossa
-  name: "Focal Fossa"
-  short_version: "20.04"
-  full_version: "20.04.2"
-  full_version_desktop: "20.04.2.0"
-  release_date: "April 2020"
-  eol: "2025年4月"
-  release_notes_url: "https://wiki.ubuntu.com/FocalFossa/ReleaseNotes"
+  name: 'Focal Fossa'
+  short_version: '20.04'
+  full_version: '20.04.3'
+  release_date: 'April 2020'
+  eol: '2025年4月'
+  release_notes_url: 'https://wiki.ubuntu.com/FocalFossa/ReleaseNotes'
 openstack_lts:
   slug: Ussuri
 previous_lts:
-  name: "Bionic Beaver"
-  short_version: "18.04"
-  full_version: "18.04.5"
-  release_date: "April 2018"
-  eol: "2023年4月"
+  name: 'Bionic Beaver'
+  short_version: '18.04'
+  full_version: '18.04.5'
+  release_date: 'April 2018'
+  eol: '2023年4月'
 previous_previous_lts:
-  name: "Xenial Xerus"
-  short_version: "16.04"
-  full_version: "16.04.7"
+  name: 'Xenial Xerus'
+  short_version: '16.04'
+  full_version: '16.04.7'
 
 checksums:
   desktop:
-    "21.04": "fa95fb748b34d470a7cfa5e3c1c8fa1163e2dc340cd5a60f7ece9dc963ecdf88 *ubuntu-21.04-desktop-amd64.iso"
-    "20.04.2.0": "93bdab204067321ff131f560879db46bee3b994bf24836bb78538640f689e58f *ubuntu-20.04.2.0-desktop-amd64.iso"
+    '21.04': 'fa95fb748b34d470a7cfa5e3c1c8fa1163e2dc340cd5a60f7ece9dc963ecdf88 *ubuntu-21.04-desktop-amd64.iso'
+    '20.04.3': '5fdebc435ded46ae99136ca875afc6f05bde217be7dd018e1841924f71db46b5 *ubuntu-20.04.3-desktop-amd64.iso'
   live-server:
-    "21.04": "e4089c47104375b59951bad6c7b3ee5d9f6d80bfac4597e43a716bb8f5c1f3b0 *ubuntu-21.04-live-server-amd64.iso"
-    "20.04.2": "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423 *ubuntu-20.04.2-live-server-amd64.iso"
+    '21.04': 'e4089c47104375b59951bad6c7b3ee5d9f6d80bfac4597e43a716bb8f5c1f3b0 *ubuntu-21.04-live-server-amd64.iso'
+    '20.04.3': 'f8e3086f3cea0fb3fefb29937ab5ed9d19e767079633960ccb50e76153effc98 *ubuntu-20.04.3-live-server-amd64.iso'
   desktop-arm64+raspi:
-    "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
+    '21.04': 'd89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz'
   server-arm64+raspi:
-    "21.04": "3df85b93b66ccd2d370c844568b37888de66c362eebae5204bf017f6f5875207 *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz"
-    "20.04.2": "31884b07837099a5e819527af66848a9f4f92c1333e3ef0693d6d77af66d6832 *ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz"
+    '21.04': '3df85b93b66ccd2d370c844568b37888de66c362eebae5204bf017f6f5875207 *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz'
+    '20.04.3': '7e405f473d8a9e3254cd702edaeecd5509a85cde1e9e99e120f6c82156c6958f *ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz'
   server-armhf+raspi:
-    "21.04": "c9a9a5177a03fcbb6203b38e5c3c4e5447fd9e8891515da4146f319f04eb3495 *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz"
-    "20.04.2": "7b348d080648b8e36e1f29671afd973a0878503091b935b69828f2c7722dfb58 *ubuntu-20.04.2-preinstalled-server-armhf+raspi.img.xz"
+    '21.04': 'c9a9a5177a03fcbb6203b38e5c3c4e5447fd9e8891515da4146f319f04eb3495 *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz'
+    '20.04.3': '1984c349d5d6b74279402325b6985587d1d32c01695f2946819ce25b638baa0e *ubuntu-20.04.3-preinstalled-server-armhf+raspi.img.xz'

--- a/templates/download/desktop.html
+++ b/templates/download/desktop.html
@@ -16,8 +16,8 @@
   </section>
   <section class="p-strip--light">
     <div class="u-fixed-width">
-      <h2>Ubuntu {{ releases.lts.full_version_desktop }} LTS</h2>
-      <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right"> 
+      <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
+      <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
         <div class="col-8 p-divider__block">
           <p class="u-no-padding--top">下载专为桌面PC和笔记本精心打造的Ubuntu长期支持(<abbr title="Long-term support">LTS</abbr>)版本。LTS意为“长期支持”，一般为5年。LTS版本将提供免费安全和维护更新至 {{ releases.lts.eol }}。</p>
           <p><a href="{{ releases.lts.release_notes_url }}" class="p-link--external">Ubuntu {{ releases.lts.short_version }} LTS发布说明</a></p>
@@ -32,21 +32,21 @@
         </div>
         <div class="col-4">
           <p>
-            <a class="p-button--positive is-wide" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version_desktop }}-desktop-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">下载</a>
+            <a class="p-button--positive is-wide" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-desktop-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">下载</a>
             <script>performance.mark("Download (Desktop) button rendered")</script>
           </p>
           <p><small>如需其他版本的Ubuntu，包括BT下载，网络安装器，本地镜像站和历史版本，请访问 <a href="/download/alternative-downloads">其他下载</a>。</small></p>
         </div>
       </div>
     </div>
-  
+
     {% if releases.latest.short_version > releases.lts.short_version %}
     <div class="p-strip is-shallow">
       <div class="u-fixed-width">
         <hr>
       </div>
     </div>
-  
+
     <div class="u-fixed-width">
       <h2>Ubuntu {{ releases.latest.full_version }}</h2>
       <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
@@ -67,14 +67,14 @@
     </div>
     {% endif %}
   </section>
-  
+
   {% include '/shared/_everywhere.html' %}
-  
+
   <section class="p-strip--light">
     <div class="u-fixed-width">
       <h2>切换到Ubuntu的简单方法</h2>
     </div>
-  
+
     <div class="row u-equal-height">
       <div class="col-4 p-card">
         <div class="p-heading-icon--small">
@@ -99,7 +99,7 @@
           <li class="p-list__item"><a class="p-link--external" href="https://ubuntu.com/tutorials/tutorial-create-a-usb-stick-on-ubuntu">如何在Ubuntu上创建一个启动U盘</a></li>
         </ul>
       </div>
-  
+
       <div class="col-4 p-card">
         <div class="p-heading-icon--small">
           <div class="p-heading-icon__header">
@@ -123,7 +123,7 @@
           <li class="p-list__item"><a class="p-link--external" href="https://ubuntu.com/tutorials/tutorial-create-a-usb-stick-on-windows">如何在Windows上创建一个启动U盘</a></li>
         </ul>
       </div>
-  
+
       <div class="col-4 p-card">
         <div class="p-heading-icon--small">
           <div class="p-heading-icon__header">


### PR DESCRIPTION
## Done
- Remove `releases.lts.full_version_desktop` and replace with `releases.lts.full_version` as they are one of the same now
- Bump the point release from [20.04.2|20.04.2.0] to 20.04.3

## QA
- Check the file names and checksums match the ones in the issue.
- Go to the demo
- Check that download paths to 20.04.3 all work but **the download wont yet**

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/4324

