### PR TITLE
Add pattern to email fields

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -10,7 +10,7 @@
       <div>
         <label>
           <span class="u-no-margin--top">工作邮箱:<span>*</span></span>
-          <input required  id="email" name="email" maxlength="255" type="email" />
+          <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
         </label>
       </div>
 

--- a/templates/contact/index.html
+++ b/templates/contact/index.html
@@ -43,7 +43,7 @@
         </li>
         <li>
           <label for="email">工作邮箱：</label>
-          <input required="" id="email" name="email" maxlength="255" type="email" aria-label="Email" aria-required="true">
+          <input required="" id="email" name="email" maxlength="255" type="email" aria-label="Email" aria-required="true" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
         </li>
         <li>
           <label for="company">公司名称：</label>
@@ -73,7 +73,7 @@
       </ul>
     </fieldset>
   </form>
- 
+
   <script src="https://assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
   <!-- /MARKETO FORM -->
       </div>

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -47,7 +47,7 @@
                 ) | safe
               }}
             </div>
-          </div>          
+          </div>
         </div>
 
         <div class="col-4 col-start-large-9">
@@ -66,7 +66,7 @@
            </li>
            <li>
              <label for="email">工作邮箱：</label>
-             <input required="" id="email" name="email" maxlength="255" type="email" aria-label="Email" aria-required="true">
+             <input required="" id="email" name="email" maxlength="255" type="email" aria-label="Email" aria-required="true" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
            </li>
            <li>
              <label for="company">公司名称：</label>
@@ -100,7 +100,7 @@
          </ul>
         </fieldset>
         </form>
-        
+
         <script src="https://assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
 
         <!-- /MARKETO FORM -->

--- a/templates/engage/2004-launch.html
+++ b/templates/engage/2004-launch.html
@@ -62,7 +62,7 @@
        </li>
        <li>
          <label for="email">工作邮箱：</label>
-         <input required="" id="email" name="email" maxlength="255" type="email" aria-label="Email" aria-required="true">
+         <input required="" id="email" name="email" maxlength="255" type="email" aria-label="Email" aria-required="true" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
        </li>
        <li>
          <label for="company">公司名称：</label>
@@ -96,7 +96,7 @@
      </ul>
    </fieldset>
   </form>
-  
+
   <script src="https://assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
 
   <!-- /MARKETO FORM -->

--- a/templates/engage/shared/_engage_form.html
+++ b/templates/engage/shared/_engage_form.html
@@ -11,7 +11,7 @@
      </li>
      <li>
        <label for="email">工作邮箱：</label>
-       <input required="" id="email" name="email" maxlength="255" type="email" aria-label="Email" aria-required="true">
+       <input required="" id="email" name="email" maxlength="255" type="email" aria-label="Email" aria-required="true" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
      </li>
      <li>
        <label for="company">公司名称：</label>
@@ -28,7 +28,7 @@
      <li>
       <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox"><label for="canonicalUpdatesOptIn"><small>我同意接收有关Canonical的产品和服务信息。</small></label>
      </li>
-     <li>           
+     <li>
       <p><small>在提交此表格的同时，我确认已阅读和同意<a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy/contact">的隐私声明</a>和<a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy">隐私政策</small></a>。
         <input name="RichText" aria-label="RichText" type="hidden">
       </p>


### PR DESCRIPTION
## Done
Add pattern to all email fields

## QA
- Go /contact and try and submit `foo@bar` which is a validate HTML5 email but we block and expect `.com` at the end. 
