### PR TITLE
Fix the blog navi icon

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -42,11 +42,11 @@
           <li class="p-pagination__item">
             {% if current_page > 1 %}
               <a href="/blog?page={{ current_page - 1 }}" class="p-pagination__link--previous">
-                <i class="p-icon--contextual-menu">Previous page</i>
+                <i class="p-icon--chevron-down">Previous page</i>
               </a>
             {% else %}
             <span class="p-pagination__link--previous is-disabled">
-              <i class="p-icon--contextual-menu">Previous page</i>
+              <i class="p-icon--chevron-down">Previous page</i>
             </span>
             {% endif %}
           </li>
@@ -114,11 +114,11 @@
           <li class="p-pagination__item">
             {% if current_page != total_pages %}
               <a href="/blog?page={{ current_page + 1 }}" class="p-pagination__link--next">
-                <i class="p-icon--contextual-menu">Next page</i>
+                <i class="p-icon--chevron-down">Next page</i>
               </a>
             {% else %}
             <span class="p-pagination__link--next is-disabled">
-              <i class="p-icon--contextual-menu">Next page</i>
+              <i class="p-icon--chevron-down">Next page</i>
             </span>
             {% endif %}
           </li>

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -5,7 +5,7 @@
 
   <div class="blog-p-card__content">
     <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_3647" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-      <h3 class="p-card--title p-heading--four">选择您感兴趣的主题</h3>
+      <h3 class="p-card--title p-heading--four">订阅您感兴趣的主题</h3>
 
       <div>
         <label>

--- a/templates/server/secondary-nav.html
+++ b/templates/server/secondary-nav.html
@@ -13,6 +13,9 @@
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link p-link--soft" href="https://ubuntu.com/server/docs">Ubuntu Server文档</a>
         </li>
+        <li class="breadcrumbs__item">
+          <a class="breadcrumbs__link p-link--soft" href="https://ubuntu.com/security/notices">Ubuntu安全通告</a>
+        </li>
       </ul>
      
     </div>


### PR DESCRIPTION
## Done

- Ａdd a sub-tab for security notices
- Update blog subscription text because no more than 1 options are available 
- Fix the navigation icon for previous and next page display issues since the "p-icon--contextual-menu" is replaced with "p-icon--chevron-down" in [Vanilla V3](https://vanillaframework.io/docs/migration-guide-to-v3) 


## Screenshots
![image](https://user-images.githubusercontent.com/692206/151485043-7a14a7c4-0097-43e1-8521-23ad10225b1f.png)

