### PR TITLE
Remove unused canonicalwebteam.search module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ canonicalwebteam.flask_base==1.0.3
 canonicalwebteam.discourse==4.0.8
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
-canonicalwebteam.search==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 pyyaml==5.4.1


### PR DESCRIPTION
This appears to have been added in 3ebc269d9326980bf9a3d281fbdf6f2dd7320cf7,
even though I don't think it was used even then.

QA
--

`dotrun clean`, then `dotrun` run the site, check it works.