### PR TITLE
Add discourse API key

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -6,6 +6,16 @@ env:
   - name: SENTRY_DSN
     value: https://06096678a069442f9e6f72aa985f15ca@sentry.is.canonical.com//32
 
+  - name: DISCOURSE_API_KEY
+    secretKeyRef:
+      key: ubuntu-api-key
+      name: discourse-api
+
+  - name: DISCOURSE_API_USERNAME
+    secretKeyRef:
+      key: ubuntu-api-username
+      name: discourse-api
+
 useProxy: false
 
 readinessPath: "/_status/ping"


### PR DESCRIPTION
## Done

Some discourse API features namely the discourse plugin data-explorer that will be used in [new engage pages]() and blocking google search from [indexing discourse posts](https://github.com/canonical-web-and-design/web-squad/issues/5661) require discourse API keys.

## QA

No QA really, once we merge this, we can change the permissions so that engage pages are not accessible without login, but this can only happen after merge.

Just check that `/engage` works and check the individual engage pages work

## Issue / Card

Partially https://github.com/canonical-web-and-design/web-squad/issues/5661
Partially https://github.com/canonical-web-and-design/ubuntu.com/issues/11503

