### PR TITLE
Fix: remove assets preconnect url in live links check

### DIFF
--- a/.github/workflows/live-links.yml
+++ b/.github/workflows/live-links.yml
@@ -39,6 +39,7 @@ jobs:
             https://ubuntu.com/static/css/*
             https://www.xilinx.com/applications/*
             https://player.vimeo.com/video/*
+            https://assets.ubuntu.com/v1
 
           [output]
           status=0


### PR DESCRIPTION
## Done

This removes the base URL of the assets URL from the live link checks as this would always return a 401 Unauthorized error.
This fixes the link checker errors

## QA

https://warthogs.atlassian.net/browse/WD-21846


## Issue / Card

[WD-21846](https://warthogs.atlassian.net/browse/WD-21846)

## Screenshots
![image](https://github.com/user-attachments/assets/9974b773-eae2-4373-8641-928a00617239)


[WD-21846]: https://warthogs.atlassian.net/browse/WD-21846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ