### PR TITLE
Ignore assets base URL in LinkChecker

### DIFF
--- a/.github/workflows/live-links.yml
+++ b/.github/workflows/live-links.yml
@@ -39,7 +39,7 @@ jobs:
             https://ubuntu.com/static/css/*
             https://www.xilinx.com/applications/*
             https://player.vimeo.com/video/*
-            https://assets.ubuntu.com/v1
+            ^https://assets\.ubuntu\.com/?$
 
           [output]
           status=0


### PR DESCRIPTION
## Done

The key issue here is that LinkChecker is trying to follow <link rel="preconnect" href="https://assets.ubuntu.com">, which is a performance optimization, but not a traditional navigable page — and the base URL https://assets.ubuntu.com itself returns a 401 Unauthorized.

- excludes only the root https://assets.ubuntu.com and not subpaths like /v1/...
