### PR TITLE
feat: Add redirect for pricing calculator

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -2,3 +2,4 @@
 iot(?P<path>.*)/?: '/internet-of-things{path}/'
 landscape/install/?: "https://ubuntu.com/landscape/install"
 support/advantage/?: "/support/pro"
+cloud/openstack/tco-calculator/?: "https://canonical.com/solutions/infrastructure/private-cloud-pricing"


### PR DESCRIPTION
## Done

- Add redirect for from the tco-calculator page to the new c.com pricing calculator

## QA

Open this link:
https://cn-ubuntu-com-769.demos.haus/cloud/openstack/tco-calculator

See it redirects to:
https://canonical.com/solutions/infrastructure/private-cloud-pricing

## Issue / Card

https://warthogs.atlassian.net/browse/WD-23430
