### PR TITLE
fix: failing build for releases

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -29,7 +29,7 @@ demo:
   env:
     - name: HTTP_PROXY
       value: http://squid.internal:3128
-    
+
     - name: HTTPS_PROXY
       value: http://squid.internal:3128
 

--- a/tests/test_releases_yaml_reference.py
+++ b/tests/test_releases_yaml_reference.py
@@ -16,8 +16,10 @@ class TestReleasesYamlReferences(TestCase):
     def setUpClass(cls):
 
         with app.app_context():
-            releases_url = app.config["UBUNTU_COM_RELEASES"]
-            cls.releases_data = get_releases(releases_url)
+            cls.releases_data = get_releases(
+                "https://raw.githubusercontent.com/canonical/"
+                "ubuntu.com/main/releases.yaml"
+            )
 
         cls.valid_paths = set()
         cls._build_paths(cls.releases_data, "releases", cls.valid_paths)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -43,11 +43,6 @@ app = FlaskBase(
 app.config["CACHE_TYPE"] = "SimpleCache"
 cache = Cache(app)
 
-# initialize releases url
-app.config["UBUNTU_COM_RELEASES"] = (
-    "https://raw.githubusercontent.com/canonical/ubuntu.com/main/releases.yaml"
-)
-
 
 # Set up cache functions for cookie consent service
 def get_cache(key):
@@ -184,9 +179,16 @@ def navigation_nojs():
 app.add_url_rule("/navigation", view_func=navigation_nojs)
 
 # read releases.yaml
-releases = get_releases(app.config["UBUNTU_COM_RELEASES"])
+try:
+    releases = get_releases(
+        "https://raw.githubusercontent.com/canonical/"
+        "ubuntu.com/main/releases.yaml"
+    )
+except Exception as e:
+    app.logger.warning(f"Failed to load releases data: {e}")
+    releases = {}
 
-# read navigation-dropdown.yaml
+# read navigation-dropdown.yamld
 with open("navigation-dropdown.yaml") as dropdown_file:
     dropdown_data = yaml.load(dropdown_file, Loader=yaml.FullLoader)
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -179,16 +179,12 @@ def navigation_nojs():
 app.add_url_rule("/navigation", view_func=navigation_nojs)
 
 # read releases.yaml
-try:
-    releases = get_releases(
-        "https://raw.githubusercontent.com/canonical/"
-        "ubuntu.com/main/releases.yaml"
-    )
-except Exception as e:
-    app.logger.warning(f"Failed to load releases data: {e}")
-    releases = {}
+releases = get_releases(
+    "https://raw.githubusercontent.com/canonical/"
+    "ubuntu.com/main/releases.yaml"
+)
 
-# read navigation-dropdown.yamld
+# read navigation-dropdown.yaml
 with open("navigation-dropdown.yaml") as dropdown_file:
     dropdown_data = yaml.load(dropdown_file, Loader=yaml.FullLoader)
 


### PR DESCRIPTION
## Done

- Load releases URL directly without adding it to app config
- Add error catching when loading releases from ubuntu.com releases.yaml
- Note: Update jenkins config to track changes from main branch after merge

## QA

- See that [this job](https://jenkins.canonical.com/webteam/job/cn.ubuntu.com/147/) builds successfully

## Issue / Card

Fixes [WD-35547](https://warthogs.atlassian.net/browse/WD-35547)

## Screenshots

[if relevant, include a screenshot]


[WD-35547]: https://warthogs.atlassian.net/browse/WD-35547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ