### PR TITLE
build: unblock release data fetch with caching

### DIFF
--- a/webapp/api.py
+++ b/webapp/api.py
@@ -3,7 +3,7 @@ import yaml
 
 
 def get_releases(url):
-    response = requests.get(url)
+    response = requests.get(url, timeout=10)
     response.raise_for_status()
 
     data = yaml.load(response.text, Loader=yaml.FullLoader)

--- a/webapp/api.py
+++ b/webapp/api.py
@@ -4,6 +4,10 @@ import yaml
 
 logger = logging.getLogger(__name__)
 RELEASES_CACHE_KEY = "releases_data"
+RELEASES_URL = (
+    "https://raw.githubusercontent.com/canonical/"
+    "ubuntu.com/main/releases.yaml"
+)
 
 
 def get_releases(url):
@@ -44,7 +48,7 @@ def get_releases(url):
     return data
 
 
-def get_releases_cached(cache, url):
+def get_releases_cached(cache):
     """
     Get releases from cache or fetch and cache if missing.
     """
@@ -55,11 +59,11 @@ def get_releases_cached(cache, url):
         return cached_data
 
     try:
-        logger.info(f"Fetching releases from {url}...")
-        data = get_releases(url)
-        # Set timeout to an hour
+        logger.info(f"Fetching releases from {RELEASES_URL}...")
+        data = get_releases(RELEASES_URL)
+        # Cache for one hour
         cache.set(RELEASES_CACHE_KEY, data, timeout=3600)
-        logger.info("Releases fetched and cached successfully")
+        logger.debug("Releases fetched and cached successfully")
         return data
     except Exception as e:
         logger.error(f"Failed to fetch releases: {e}")

--- a/webapp/api.py
+++ b/webapp/api.py
@@ -1,8 +1,13 @@
+import logging
 import requests
 import yaml
 
+logger = logging.getLogger(__name__)
+RELEASES_CACHE_KEY = "releases_data"
+
 
 def get_releases(url):
+    """Fetch releases.yaml from the given URL."""
     response = requests.get(url, timeout=10)
     response.raise_for_status()
 
@@ -37,3 +42,25 @@ def get_releases(url):
                         info[key] = f"{parts[1]}年{month_map[parts[0]]}月"
 
     return data
+
+
+def get_releases_cached(cache, url):
+    """
+    Get releases from cache or fetch and cache if missing.
+    """
+    cached_data = cache.get(RELEASES_CACHE_KEY)
+
+    if cached_data is not None:
+        logger.info("Releases loaded from cache")
+        return cached_data
+
+    try:
+        logger.info(f"Fetching releases from {url}...")
+        data = get_releases(url)
+        # Set timeout to an hour
+        cache.set(RELEASES_CACHE_KEY, data, timeout=3600)
+        logger.info("Releases fetched and cached successfully")
+        return data
+    except Exception as e:
+        logger.error(f"Failed to fetch releases: {e}")
+        raise

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -10,7 +10,7 @@ from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
 from flask_caching import Cache
 from jinja2 import ChoiceLoader, FileSystemLoader
-from webapp.api import get_releases
+from webapp.api import get_releases_cached
 from slugify import slugify
 
 from webapp.navigation import (
@@ -178,11 +178,6 @@ def navigation_nojs():
 
 app.add_url_rule("/navigation", view_func=navigation_nojs)
 
-# read releases.yaml
-releases = get_releases(
-    "https://raw.githubusercontent.com/canonical/"
-    "ubuntu.com/main/releases.yaml"
-)
 
 # read navigation-dropdown.yaml
 with open("navigation-dropdown.yaml") as dropdown_file:
@@ -192,8 +187,12 @@ with open("navigation-dropdown.yaml") as dropdown_file:
 # Template context
 @app.context_processor
 def context():
+    releases_url = (
+        "https://raw.githubusercontent.com/canonical/"
+        "ubuntu.com/main/releases.yaml"
+    )
     return {
-        "releases": releases,
+        "releases": get_releases_cached(cache, releases_url),
         "dropdown": dropdown_data,
         "get_current_page_bubble": get_current_page_bubble,
         "get_navigation": get_navigation,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -187,12 +187,8 @@ with open("navigation-dropdown.yaml") as dropdown_file:
 # Template context
 @app.context_processor
 def context():
-    releases_url = (
-        "https://raw.githubusercontent.com/canonical/"
-        "ubuntu.com/main/releases.yaml"
-    )
     return {
-        "releases": get_releases_cached(cache, releases_url),
+        "releases": get_releases_cached(cache),
         "dropdown": dropdown_data,
         "get_current_page_bubble": get_current_page_bubble,
         "get_navigation": get_navigation,


### PR DESCRIPTION
## Done

- Fetch releases asynchronously to prevent blocking when building
- Call get_releases endpoint asynchronously

## QA

- Go to /download
- See that the releases are using the data from [releases.yaml](https://raw.githubusercontent.com/canonical/ubuntu.com/main/releases.yaml)
- See that [build](https://jenkins.canonical.com/webteam/job/cn.ubuntu.com/158/) passes

## Issue / Card

Fixes [WD-35934](https://warthogs.atlassian.net/browse/WD-35934)

## Screenshots

[if relevant, include a screenshot]


[WD-35934]: https://warthogs.atlassian.net/browse/WD-35934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ