### PR TITLE
fix(WD-36519): include vanilla build for ps6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ env[23]/
 
 static/dist
 static/js/dist
+static/js/modules
 
 .webcache/
 .webcache_blog/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build-js": "mkdir -p static/js && webpack",
     "build-cookie-policy": "cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/dist/",
     "build-latest-news": "cp node_modules/@canonical/latest-news/dist/latest-news.js static/js/dist/",
-    "build": "mkdir -p static/js && webpack && yarn run build-css && yarn run build-cookie-policy && yarn run build-latest-news",
+    "build-vanilla-framework": "mkdir -p static/js/modules/vanilla-framework && cp -r node_modules/vanilla-framework/templates/_macros/ static/js/modules/vanilla-framework",
+    "build": "mkdir -p static/js && webpack && yarn run build-css && yarn run build-cookie-policy && yarn run build-latest-news && yarn run build-vanilla-framework",
     "start": "yarn run build && concurrently --kill-others --raw 'yarn run watch-css' 'yarn run watch-js' 'yarn run serve'",
     "test-js": "jest --passWithNoTests",
     "format-scss": "prettier -w 'static/**/*.scss'"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -58,6 +58,7 @@ loader = ChoiceLoader(
     [
         FileSystemLoader("templates"),
         FileSystemLoader("node_modules/vanilla-framework/templates/"),
+        FileSystemLoader("static/js/modules/vanilla-framework/"),
     ]
 )
 


### PR DESCRIPTION
## Done

- Updated package.json to add script for copying vanilla macros
- Updated app.py

## QA

- Checkout this pull request
- Run the project using dotrun
- Verify project runs as expected

## Issue / Card

[WD-36519](https://warthogs.atlassian.net/browse/WD-36519)



[WD-36519]: https://warthogs.atlassian.net/browse/WD-36519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ