### PR TITLE
fix: broken engage pages and blogs

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -43,6 +43,9 @@ demo:
     - name: HTTPS_PROXY
       value: http://squid.internal:3128
 
+    - name: NO_PROXY
+      value: "10.24.0.132,10.24.0.23,.internal,admin.insights.ubuntu.com,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,canonical.design,.canonical.design"
+
 extraHosts:
   - domain: ubuntu-china.cn
     useParentTLS: True

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -20,6 +20,16 @@ env:
     secretKeyRef:
       key: cookies-api-key
       name: cookies-canonical-com-credentials
+  
+  - name: WORDPRESS_APPLICATION_PASSWORD
+    secretKeyRef:
+      key: wordpress-application-password
+      name: wordpress-api
+
+  - name: WORDPRESS_USERNAME
+    secretKeyRef:
+      key: wordpress-username
+      name: wordpress-api
 
 useProxy: false
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 flask
 canonicalwebteam.flask_base==2.6.1
-canonicalwebteam.discourse==5.8.1
+canonicalwebteam.discourse==7.2.0
 canonicalwebteam.http==1.0.4
-canonicalwebteam.blog==6.8.2
+canonicalwebteam.blog==6.8.4
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
 canonicalwebteam.cookie-service==2.0.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -7,6 +7,7 @@ from canonicalwebteam import image_template
 from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
 from canonicalwebteam.discourse import DiscourseAPI, EngagePages
 from canonicalwebteam.flask_base.app import FlaskBase
+from canonicalwebteam.flask_base.env import get_flask_env
 from canonicalwebteam.templatefinder import TemplateFinder
 from flask_caching import Cache
 from jinja2 import ChoiceLoader, FileSystemLoader
@@ -155,8 +156,19 @@ app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 app.add_url_rule("/sitemap.xml", view_func=sitemap_index)
 
+WORDPRESS_USERNAME = get_flask_env("WORDPRESS_USERNAME")
+WORDPRESS_APPLICATION_PASSWORD = get_flask_env(
+    "WORDPRESS_APPLICATION_PASSWORD"
+)
+
 blog_views = BlogViews(
-    api=BlogAPI(session=session, thumbnail_width=354, thumbnail_height=199),
+    api=BlogAPI(
+        session=session,
+        thumbnail_width=354,
+        thumbnail_height=199,
+        wordpress_username=WORDPRESS_USERNAME,
+        wordpress_password=WORDPRESS_APPLICATION_PASSWORD
+    ),
     tag_ids=[3265],
     blog_title="博客",
     per_page=11,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -156,19 +156,21 @@ app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 app.add_url_rule("/sitemap.xml", view_func=sitemap_index)
 
-WORDPRESS_USERNAME = get_flask_env("WORDPRESS_USERNAME")
-WORDPRESS_APPLICATION_PASSWORD = get_flask_env(
-    "WORDPRESS_APPLICATION_PASSWORD"
-)
+WORDPRESS_USERNAME = os.getenv("WORDPRESS_USERNAME")
+WORDPRESS_APPLICATION_PASSWORD = os.getenv("WORDPRESS_APPLICATION_PASSWORD")
+
+try:
+    blog_api = BlogAPI(
+            session=session,
+            thumbnail_width=354,
+            thumbnail_height=199,
+        )
+except Exception as e:
+    blog_api = None
+    print(f"Error initializing BlogAPI: {e}")
 
 blog_views = BlogViews(
-    api=BlogAPI(
-        session=session,
-        thumbnail_width=354,
-        thumbnail_height=199,
-        wordpress_username=WORDPRESS_USERNAME,
-        wordpress_password=WORDPRESS_APPLICATION_PASSWORD
-    ),
+    api=blog_api,
     tag_ids=[3265],
     blog_title="博客",
     per_page=11,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import flask
@@ -29,6 +30,8 @@ from webapp.views import (
     BlogSitemapIndex,
     BlogSitemapPage,
 )
+
+logger = logging.getLogger(__name__)
 
 app = FlaskBase(
     __name__,
@@ -159,15 +162,28 @@ app.add_url_rule("/sitemap.xml", view_func=sitemap_index)
 WORDPRESS_USERNAME = os.getenv("WORDPRESS_USERNAME")
 WORDPRESS_APPLICATION_PASSWORD = os.getenv("WORDPRESS_APPLICATION_PASSWORD")
 
+if WORDPRESS_USERNAME and WORDPRESS_APPLICATION_PASSWORD:
+    logger.info(
+        "WordPress credentials found: username=%s", WORDPRESS_USERNAME
+    )
+else:
+    logger.warning(
+        "WordPress credentials not found. "
+        "Blog functionality will be unavailable. "
+        "Expected env vars: WORDPRESS_USERNAME, WORDPRESS_APPLICATION_PASSWORD"
+    )
+
 try:
     blog_api = BlogAPI(
             session=session,
             thumbnail_width=354,
             thumbnail_height=199,
+            wordpress_username=WORDPRESS_USERNAME,
+            wordpress_password=WORDPRESS_APPLICATION_PASSWORD,
         )
 except Exception as e:
+    logger.error("Error initializing BlogAPI: %s", str(e), exc_info=True)
     blog_api = None
-    print(f"Error initializing BlogAPI: {e}")
 
 blog_views = BlogViews(
     api=blog_api,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,6 +1,3 @@
-import logging
-import os
-
 import flask
 import talisker
 import yaml
@@ -30,8 +27,6 @@ from webapp.views import (
     BlogSitemapIndex,
     BlogSitemapPage,
 )
-
-logger = logging.getLogger(__name__)
 
 app = FlaskBase(
     __name__,
@@ -76,8 +71,8 @@ session = talisker.requests.get_session()
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
     session=session,
-    api_key=os.getenv("DISCOURSE_API_KEY"),
-    api_username=os.getenv("DISCOURSE_API_USERNAME"),
+    api_key=get_flask_env("DISCOURSE_API_KEY"),
+    api_username=get_flask_env("DISCOURSE_API_USERNAME"),
     get_topics_query_id=14,
 )
 
@@ -159,34 +154,19 @@ app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 app.add_url_rule("/sitemap.xml", view_func=sitemap_index)
 
-WORDPRESS_USERNAME = os.getenv("WORDPRESS_USERNAME")
-WORDPRESS_APPLICATION_PASSWORD = os.getenv("WORDPRESS_APPLICATION_PASSWORD")
-
-if WORDPRESS_USERNAME and WORDPRESS_APPLICATION_PASSWORD:
-    logger.info(
-        "WordPress credentials found: username=%s", WORDPRESS_USERNAME
-    )
-else:
-    logger.warning(
-        "WordPress credentials not found. "
-        "Blog functionality will be unavailable. "
-        "Expected env vars: WORDPRESS_USERNAME, WORDPRESS_APPLICATION_PASSWORD"
-    )
-
-try:
-    blog_api = BlogAPI(
-            session=session,
-            thumbnail_width=354,
-            thumbnail_height=199,
-            wordpress_username=WORDPRESS_USERNAME,
-            wordpress_password=WORDPRESS_APPLICATION_PASSWORD,
-        )
-except Exception as e:
-    logger.error("Error initializing BlogAPI: %s", str(e), exc_info=True)
-    blog_api = None
+WORDPRESS_USERNAME = get_flask_env("WORDPRESS_USERNAME")
+WORDPRESS_APPLICATION_PASSWORD = get_flask_env(
+    "WORDPRESS_APPLICATION_PASSWORD"
+)
 
 blog_views = BlogViews(
-    api=blog_api,
+    api=BlogAPI(
+        session=session,
+        thumbnail_width=354,
+        thumbnail_height=199,
+        wordpress_username=WORDPRESS_USERNAME,
+        wordpress_password=WORDPRESS_APPLICATION_PASSWORD,
+    ),
     tag_ids=[3265],
     blog_title="博客",
     per_page=11,


### PR DESCRIPTION
## Done

- Add Wordpress credentials and authentication
- Add `NO_PROXY` for demos
- Bumped blog and Discourse modules

## QA

- Go to https://cn-ubuntu-com-847.demos.haus/blog
- See that individual blog articles are loading
- Go to https://cn-ubuntu-com-847.demos.haus/engage
- See that it loads as expected

## Issue / Card

Fixes [WD-36662](https://warthogs.atlassian.net/browse/WD-36662)

## Screenshots

[if relevant, include a screenshot]


[WD-36662]: https://warthogs.atlassian.net/browse/WD-36662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ