### PR TITLE
chore: remove trailing whitespace in env section

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -20,7 +20,7 @@ env:
     secretKeyRef:
       key: cookies-api-key
       name: cookies-canonical-com-credentials
-  
+
   - name: WORDPRESS_APPLICATION_PASSWORD
     secretKeyRef:
       key: wordpress-application-password


### PR DESCRIPTION
## Done

- Remove trailing whitespace in konf file

## QA

- Cannot be QA'ed locally. Once this is merged, it should fix the failing deployment on Jenkins

## Issue / Card

[Failing deployment on Jenkins](https://jenkins.canonical.com/webteam/job/cn.ubuntu.com/172/console)

## Screenshots

[if relevant, include a screenshot]
