### PR TITLE
build: include wordpress config in charmcraft.yaml

### DIFF
--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -35,3 +35,6 @@ config:
     cookie-service-api-key:
       description: "Cookie Service API Key"
       type: secret
+    wordpress:
+      type: secret
+      description: "Wordpress credentials"


### PR DESCRIPTION
## Done

- Add config values on `charmcraft.yaml`

## QA

- Cannot be QA'ed locally. Once this is merged, it should fix the failing deployment on Jenkins
- Should fix this error:
```
The Deployment "cn-ubuntu-com" is invalid: 
* spec.template.spec.containers[0].env[8].valueFrom: Invalid value: "": may not be specified when `value` is not empty
* spec.template.spec.containers[0].env[9].valueFrom: Invalid value: "": may not be specified when `value` is not empty
```

## Issue / Card

[Fixes failing Jenkins job](https://jenkins.canonical.com/webteam/job/cn.ubuntu.com/174/console)

## Screenshots

[if relevant, include a screenshot]
