### PR TITLE
build: move proxy variables to top level

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -31,20 +31,18 @@ env:
       key: wordpress-username
       name: wordpress-api
 
+  - name: HTTP_PROXY
+    value: http://squid.internal:3128
+
+  - name: HTTPS_PROXY
+    value: http://squid.internal:3128
+
+  - name: NO_PROXY
+    value: "10.24.0.132,10.24.0.23,.internal,admin.insights.ubuntu.com,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,canonical.design,.canonical.design"
+
 useProxy: false
 
 readinessPath: "/_status/ping"
-
-demo:
-  env:
-    - name: HTTP_PROXY
-      value: http://squid.internal:3128
-
-    - name: HTTPS_PROXY
-      value: http://squid.internal:3128
-
-    - name: NO_PROXY
-      value: "10.24.0.132,10.24.0.23,.internal,admin.insights.ubuntu.com,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,canonical.design,.canonical.design"
 
 extraHosts:
   - domain: ubuntu-china.cn


### PR DESCRIPTION
## Done

- Move proxy env variables from demo only to to top level
- Allows proxy for production, staging and demo

## QA

- Go to https://cn-ubuntu-com-852.demos.haus/blog and https://cn-ubuntu-com-852.demos.haus/engage
- See that it loads as expected
- Try again on prod once merged

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
