### PR TITLE
chore: use categories to display blogs instead of tags

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask
 canonicalwebteam.flask_base==2.6.1
 canonicalwebteam.discourse==7.2.0
 canonicalwebteam.http==1.0.4
-canonicalwebteam.blog==7.0.0
+git+https://github.com/canonical/canonicalwebteam.blog.git@feat/site-category-filtering#egg=canonicalwebteam.blog
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
 canonicalwebteam.cookie-service==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask
 canonicalwebteam.flask_base==2.6.1
 canonicalwebteam.discourse==7.2.0
 canonicalwebteam.http==1.0.4
-git+https://github.com/canonical/canonicalwebteam.blog.git@feat/site-category-filtering#egg=canonicalwebteam.blog
+canonicalwebteam.blog==7.1.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
 canonicalwebteam.cookie-service==2.0.1

--- a/static/sass/_pattern_blog-article.scss
+++ b/static/sass/_pattern_blog-article.scss
@@ -50,7 +50,7 @@
   // keeps its normal multi-column card layout.
   .blog-article article {
     @media (width < $breakpoint-large) {
-      .grid-row > [class*="grid-col-"] {
+      .grid-row > [class*='grid-col-'] {
         grid-column: 1 / -1;
       }
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -161,66 +161,6 @@ WORDPRESS_APPLICATION_PASSWORD = get_flask_env(
 )
 
 
-class CNBlogViews(BlogViews):
-    def get_tag(self, slug, page=1):
-        """Keep tag pages scoped to the site's base CN blog tags."""
-        tag = self.api.get_tag_by_slug(slug)
-
-        if not tag:
-            return None
-
-        # WordPress treats multiple tag IDs as OR, so we fetch by selected tag
-        # and then apply an in-app AND filter that also requires base CN tags.
-        required_tag_ids = set(self.tag_ids + [tag["id"]])
-        filtered_articles = []
-        source_page = 1
-        source_total_pages = 1
-
-        # Walk all source pages for the selected tag to build a fully filtered
-        # result set before applying UI pagination.
-        while source_page <= source_total_pages:
-            articles, metadata = self.api.get_articles(
-                tags=[tag["id"]],
-                tags_exclude=self.excluded_tags,
-                page=source_page,
-                per_page=100,
-                status=self.status,
-            )
-
-            # Keep only posts containing every required tag ID.
-            for article in articles:
-                article_tag_ids = set(article.get("tags", []))
-                if required_tag_ids.issubset(article_tag_ids):
-                    filtered_articles.append(article)
-
-            source_total_pages = int(metadata.get("total_pages") or 0)
-            if not articles:
-                break
-
-            source_page += 1
-
-        # Paginate after filtering so counts and pages match rendered results.
-        total_posts = len(filtered_articles)
-        total_pages = (
-            (total_posts + self.per_page - 1) // self.per_page
-            if total_posts
-            else 0
-        )
-        current_page = int(page)
-        start = (current_page - 1) * self.per_page
-        end = start + self.per_page
-        page_articles = filtered_articles[start:end]
-
-        return {
-            "current_page": current_page,
-            "total_pages": total_pages,
-            "total_posts": total_posts,
-            "articles": page_articles,
-            "title": self.blog_title,
-            "tag": tag,
-        }
-
-
 blog_views = BlogViews(
     api=BlogAPI(
         session=session,
@@ -229,7 +169,6 @@ blog_views = BlogViews(
         wordpress_username=WORDPRESS_USERNAME,
         wordpress_password=WORDPRESS_APPLICATION_PASSWORD,
     ),
-    # tag_ids=[3265],
     category_ids=[4879],
     blog_title="博客",
     per_page=16,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -221,7 +221,7 @@ class CNBlogViews(BlogViews):
         }
 
 
-blog_views = CNBlogViews(
+blog_views = BlogViews(
     api=BlogAPI(
         session=session,
         thumbnail_width=354,
@@ -229,7 +229,8 @@ blog_views = CNBlogViews(
         wordpress_username=WORDPRESS_USERNAME,
         wordpress_password=WORDPRESS_APPLICATION_PASSWORD,
     ),
-    tag_ids=[3265],
+    # tag_ids=[3265],
+    category_ids=[4879],
     blog_title="博客",
     per_page=16,
 )


### PR DESCRIPTION
## Done

- Filter `/blog` by the `cn-blog` category (`category_ids=[4879]`) instead of the base tag, so category + tag queries AND server-side.
- Removed the custom `get_tag` override; base `BlogViews` now handles tag pages.
- Pointed `canonicalwebteam.blog` at the `feat/site-category-filtering` branch for `category_ids` support.
- Re-recorded the `TestRoutes.test_blog` cassette for the new `categories` request.

## QA

- Open [demo](https://cn-ubuntu-com-865.demos.haus/blog)
- Visit [/tag/ubuntu-pro](https://cn-ubuntu-com-865.demos.haus/blog/tag/ubuntu-pro) and [/blog/tag/microsoft](https://cn-ubuntu-com-865.demos.haus/blog/tag/microsoft) and 
  - confirm only Cn articles display (no English articles appear)
  - that pagination correct.

## Issue / Card
[WD-37012](http://warthogs.atlassian.net/browse/WD-37012)
[Subtask](https://warthogs.atlassian.net/browse/WD-37539)

## Screenshots

N/A


[WD-37012]: https://warthogs.atlassian.net/browse/WD-37012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ