### PR TITLE
feat: adopt canonicalwebteam.discourse response cache and rate-limit handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask
 canonicalwebteam.flask_base==2.6.1
-canonicalwebteam.discourse==7.2.0
+canonicalwebteam.discourse==7.6.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.8.4
 canonicalwebteam.templatefinder==1.0.0

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import patch
+
+from canonicalwebteam.discourse import RateLimitedError
+
+from webapp import app as app_module
+from webapp.app import app
+
+
+class TestRateLimitedErrorHandling(unittest.TestCase):
+    """
+    RateLimitedError from the discourse package must surface as a 503
+    with Retry-After, never a 500, and the body format must match what
+    the client accepts.
+    """
+
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+
+    def test_rate_limited_page_returns_styled_503(self):
+        with patch.object(
+            app_module.engage_pages,
+            "get_index",
+            side_effect=RateLimitedError(retry_after=77),
+        ):
+            response = self.client.get("/engage")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.headers.get("Retry-After"), "77")
+        self.assertTrue(response.content_type.startswith("text/html"))
+
+    def test_rate_limited_json_path_returns_json_503(self):
+        with patch.object(
+            app_module.discourse_takeovers,
+            "parse_active_takeovers",
+            side_effect=RateLimitedError(retry_after=88),
+        ):
+            response = self.client.get("/takeovers.json")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.headers.get("Retry-After"), "88")
+        self.assertTrue(response.content_type.startswith("application/json"))
+
+    def test_rate_limited_json_accept_header_returns_json_503(self):
+        with patch.object(
+            app_module.engage_pages,
+            "get_index",
+            side_effect=RateLimitedError(retry_after=77),
+        ):
+            response = self.client.get(
+                "/engage", headers={"Accept": "application/json"}
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertTrue(response.content_type.startswith("application/json"))
+
+    def test_retry_after_defaults_to_60_without_hint(self):
+        with patch.object(
+            app_module.engage_pages,
+            "get_index",
+            side_effect=RateLimitedError(retry_after=None),
+        ):
+            response = self.client.get("/engage")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.headers.get("Retry-After"), "60")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -3,7 +3,12 @@ import talisker
 import yaml
 from canonicalwebteam import image_template
 from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
-from canonicalwebteam.discourse import DiscourseAPI, EngagePages
+from canonicalwebteam.discourse import (
+    DiscourseAPI,
+    EngagePages,
+    RateLimitedError,
+    ResponseCache,
+)
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.flask_base.env import get_flask_env
 from canonicalwebteam.templatefinder import TemplateFinder
@@ -74,6 +79,7 @@ discourse_api = DiscourseAPI(
     api_key=get_flask_env("DISCOURSE_API_KEY"),
     api_username=get_flask_env("DISCOURSE_API_USERNAME"),
     get_topics_query_id=14,
+    cache=ResponseCache(ttl=300),
 )
 
 takeovers_path = "/takeovers"
@@ -144,6 +150,40 @@ def takeovers_index():
 
 
 app.add_url_rule("/takeovers.json", view_func=takeovers_json)
+
+
+@app.errorhandler(503)
+def service_unavailable(error):
+    """
+    Rendered when an upstream API (e.g. Discourse) is rate-limiting us
+    and there is no cached response to fall back on. Retry-After tells
+    well-behaved clients and crawlers when to come back.
+    """
+    accepts = flask.request.accept_mimetypes
+    wants_json = flask.request.path.endswith(".json") or (
+        accepts.accept_json and not accepts.accept_html
+    )
+    if wants_json:
+        response = flask.make_response(
+            flask.jsonify(error="Service temporarily unavailable"), 503
+        )
+    else:
+        response = flask.make_response(flask.render_template("500.html"), 503)
+    retry_after = getattr(error, "retry_after", None)
+    response.headers["Retry-After"] = str(retry_after or 60)
+    return response
+
+
+@app.errorhandler(RateLimitedError)
+def discourse_rate_limited(error):
+    """
+    The discourse package raises RateLimitedError when Discourse
+    returns 429 and no cached response is available; serve the same
+    503 as any other upstream outage.
+    """
+    return service_unavailable(error)
+
+
 app.add_url_rule("/takeovers", view_func=takeovers_index)
 
 


### PR DESCRIPTION
## Done

- Bump `canonicalwebteam.discourse` 7.2.0 → 7.6.0 and pass a `ResponseCache` (5 min TTL) to the shared `DiscourseAPI`, so engage/takeovers renders serve from cache instead of calling Discourse on every request
- Add a 503 handler (`Retry-After` header, JSON body for `.json` paths and JSON-accepting clients) and translate the package's new `RateLimitedError` into it, so Discourse rate limits return 503 instead of 500
- Tests for the handlers (HTML/JSON negotiation, Retry-After propagation and default)

## Why

Crawler traffic recently exhausted the Discourse admin API quota (60 req/min, shared globally per instance) and 500'd Discourse-backed pages. 
cn.ubuntu.com's engage pages query the same discourse.ubuntu.com instance, uncached — both suffering from and contributing to the shared-quota exhaustion. 
The caching + circuit breaker live in the package (canonical/canonicalwebteam.discourse#227); this adopts them. Companion PRs: canonical/ubuntu.com#16551, canonical/canonical.com#2722.

## QA

- Check `/engage`, an individual engage page, `/takeovers` and `/takeovers.json` load normally
- Spot-check an engage page containing lists/blockquotes for the parser changes above
- Repeat visits within 5 min should not re-hit the Discourse API