### PR TITLE
feat: increase default Cache-Control max-age to 1 hour

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -26,6 +26,27 @@ class TestRoutes(unittest.TestCase):
 
         self.assertEqual(self.client.get("/not-found-url").status_code, 404)
 
+    def test_default_cache_control(self):
+        """
+        Successful responses without their own Cache-Control
+        should be cacheable for 1 hour
+        """
+
+        response = self.client.get("/fish")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.cache_control.max_age, 3600)
+
+    def test_status_endpoints_not_cached(self):
+        """
+        Status endpoints should never be cached
+        """
+
+        response = self.client.get("/_status/check")
+
+        self.assertTrue(response.cache_control.no_store)
+        self.assertIsNone(response.cache_control.max_age)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -43,6 +43,26 @@ app.config["CACHE_TYPE"] = "SimpleCache"
 cache = Cache(app)
 
 
+@app.after_request
+def set_default_cache_control(response):
+    """
+    Cache responses for 1 hour instead of flask-base's 60s default.
+    Runs before flask-base's hook, which keeps an existing max-age.
+    Views that set their own Cache-Control are left untouched.
+    """
+    if (
+        not flask.request.path.startswith("/_status")
+        and response.status_code == 200
+        and response.cache_control.max_age is None
+        and not response.cache_control.no_store
+        and not response.cache_control.no_cache
+        and not response.cache_control.private
+    ):
+        response.cache_control.max_age = 3600
+
+    return response
+
+
 # Set up cache functions for cookie consent service
 def get_cache(key):
     return cache.get(key)


### PR DESCRIPTION
## Done
- Set the default Cache-Control: max-age to 3600s (was flask-base's 60s default), so content-cache can cache pages for 1 hour
- Registered as an after_request hook that runs before flask-base's, which then skips its 60s default; stale-while-revalidate/stale-if-error are still applied
- Views that set their own max-age (e.g. /takeovers.json) or opt out via no-store/no-cache/private are untouched; /_status stays no-store
- Added tests for the 1h default and for explicit max-age being preserved

## QA
Run the site and check 
```
curl -sI https://cn-ubuntu-com-868.demos.haus/ | grep -i cache-control
```
 returns 
 `max-age=3600, stale-while-revalidate=86400, stale-if-error=300`
 
Check 
```
curl -sI lhttps://cn-ubuntu-com-868.demos.haus/_status/check | grep -i cache-control
```
still returns no-store

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
